### PR TITLE
Add QuickScore search back to sticky header

### DIFF
--- a/packages/web/src/lib/components/StickyHeader.svelte
+++ b/packages/web/src/lib/components/StickyHeader.svelte
@@ -1,115 +1,184 @@
 <script>
   import * as m from "$lib/paraglide/messages";
-  import { onMount } from "svelte";
+  import { goto } from "$app/navigation";
+  import { QuickScore } from "quick-score";
+  import { getLocale, locales, setLocale } from "$lib/paraglide/runtime";
 
+  export let agencies = [];
+
+  let query = "";
+  let results = [];
+  let selectedIndex = -1;
+  let previousQuery = "";
   let mobileMenuOpen = false;
-  let currentLang = "en";
 
-  onMount(() => {
-    // Safely get current language from URL path on client side only
-    const path = window.location.pathname;
-    if (path.startsWith("/es")) {
-      currentLang = "es";
-    } else {
-      currentLang = "en";
+  $: currentLocale = getLocale();
+
+  const toLabel = (item) =>
+    item?.canonical_name || item?.names?.[0] || item?.agency_slug || "Unknown agency";
+  const toStops = (item) => item?.all_stops_total;
+  const formatStops = (value) => {
+    const numeric = typeof value === "string" ? Number(value) : value;
+    if (!Number.isFinite(numeric)) return null;
+    return new Intl.NumberFormat("en-US", { maximumFractionDigits: 0 }).format(numeric);
+  };
+  const toSubLabel = (item) => [item?.city].filter(Boolean).join(" • ");
+  const toSlug = (item) => item?.agency_slug || item?.slug || item?.id;
+
+  $: searchableAgencies = (agencies || []).map((item) => ({
+    ...item,
+    search: [
+      item?.canonical_name,
+      item?.agency_slug,
+      ...(item?.names || []),
+      item?.city,
+      item?.zip,
+    ]
+      .filter(Boolean)
+      .join(" "),
+  }));
+
+  $: scorer = searchableAgencies.length ? new QuickScore(searchableAgencies, ["search"]) : null;
+
+  $: if (query.trim() !== previousQuery) {
+    previousQuery = query.trim();
+    selectedIndex = -1;
+  }
+
+  $: if (query.trim() && scorer) {
+    const scored = scorer.search(query.trim());
+    const reranked = scored
+      .slice(0, 25)
+      .sort((a, b) => {
+        const aStops = toStops(a.item);
+        const bStops = toStops(b.item);
+        const aValue = typeof aStops === "string" ? Number(aStops) : aStops ?? 0;
+        const bValue = typeof bStops === "string" ? Number(bStops) : bStops ?? 0;
+        if (bValue !== aValue) return bValue - aValue;
+        return b.score - a.score;
+      })
+      .slice(0, 10);
+    results = reranked;
+  } else {
+    results = [];
+  }
+
+  const resetSearch = () => {
+    query = "";
+    results = [];
+    selectedIndex = -1;
+  };
+
+  const handleSelect = (item) => {
+    const slug = toSlug(item);
+    if (!slug) return;
+    resetSearch();
+    goto(`/agency/${slug}`).catch(() => {
+      window.location.href = `/agency/${slug}`;
+    });
+  };
+
+  const handleKeydown = (event) => {
+    if (!results.length) return;
+
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      selectedIndex = (selectedIndex + 1) % results.length;
+      return;
     }
-  });
 
-  const handleLanguageChange = (event) => {
-    const newLang = event.target.value;
-    const currentPath = window.location.pathname;
-    const newPath = currentPath.replace(/^\/(en|es)/, `/${newLang}`);
-    window.location.href = newPath;
+    if (event.key === "ArrowUp") {
+      event.preventDefault();
+      selectedIndex = (selectedIndex - 1 + results.length) % results.length;
+      return;
+    }
+
+    if (event.key === "Enter") {
+      event.preventDefault();
+      const selected = results[selectedIndex]?.item || results[0]?.item;
+      if (selected) handleSelect(selected);
+      return;
+    }
+
+    if (event.key === "Escape") {
+      resetSearch();
+    }
+  };
+
+  const handleLocaleChange = (event) => {
+    const nextLocale = event?.currentTarget?.value;
+    if (!nextLocale || nextLocale === currentLocale) return;
+    setLocale(nextLocale);
   };
 </script>
 
-<header class="sticky top-0 z-50 border-b-4 border-b-[#28AF57] bg-white/95 backdrop-blur-sm shadow-sm">
+<header class="sticky top-0 z-50 border-b-6 border-b-[#2c9166] bg-white/95 backdrop-blur-sm shadow-sm">
   <div class="mx-auto max-w-7xl px-6">
-    <div class="flex items-center justify-between py-3">
-      <!-- Left: Title + Navigation -->
-      <div class="flex items-center gap-6">
-        <h1 class="text-lg font-bold text-[#28AF57]">
-          {m.home_header_title()}
-        </h1>
+    <div class="flex flex-col gap-3 py-3 md:flex-row md:items-center md:justify-between md:gap-4">
+      <a href="/" class="shrink-0 text-2xl font-bold text-[#2c9166] no-underline md:text-3xl">
+        {m.home_header_title()}
+      </a>
 
-        <!-- Desktop nav -->
-        <nav class="hidden items-center gap-4 md:flex">
-          <a
-            href="#search"
-            class="text-sm font-medium text-slate-700 no-underline transition-colors hover:text-[#28AF57]"
-          >
-            Search
-          </a>
-          <span class="text-slate-300">•</span>
-          <a
-            href="#about"
-            class="text-sm font-medium text-slate-700 no-underline transition-colors hover:text-[#28AF57]"
-          >
-            {m.home_toc_learn()}
-          </a>
-          <span class="text-slate-300">•</span>
-          <a
-            href="#download"
-            class="text-sm font-medium text-slate-700 no-underline transition-colors hover:text-[#28AF57]"
-          >
-            {m.home_toc_download()}
-          </a>
-        </nav>
+      <div class="relative w-full md:flex-1 md:max-w-2xl md:mx-auto">
+        <input
+          type="search"
+          placeholder={m.search_placeholder()}
+          bind:value={query}
+          on:keydown={handleKeydown}
+          aria-label={m.search_aria_label()}
+          autocomplete="off"
+          class="w-full rounded-lg border-2 border-[#2c9166] bg-white px-4 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#2c9166] focus:ring-offset-1"
+        />
+        {#if results.length}
+          <ul class="absolute left-0 right-0 top-full z-50 mt-1 max-h-80 overflow-y-auto rounded-lg border border-slate-200 bg-white py-1 shadow-lg">
+            {#each results as result, index}
+              {@const slug = toSlug(result.item)}
+              {@const href = slug ? `/agency/${slug}` : "#"}
+              {@const stops = formatStops(toStops(result.item))}
+              <li role="option">
+                <a
+                  {href}
+                  on:click={slug ? resetSearch : undefined}
+                  aria-disabled={!slug}
+                  class="flex flex-col gap-1 px-4 py-2 text-sm text-slate-900 no-underline hover:bg-[#2c9166]/10 {index === selectedIndex ? 'bg-[#2c9166]/10' : ''}"
+                >
+                  <span class="font-semibold text-slate-900">{toLabel(result.item)}</span>
+                  {#if stops || toSubLabel(result.item)}
+                    <span class="flex items-center gap-2 text-xs text-slate-500">
+                      {#if stops}
+                        <span class="font-semibold text-slate-800">{stops} stops</span>
+                      {/if}
+                      {#if toSubLabel(result.item)}
+                        <span class="opacity-60">•</span>
+                        <span>{toSubLabel(result.item)}</span>
+                      {/if}
+                    </span>
+                  {/if}
+                </a>
+              </li>
+            {/each}
+          </ul>
+        {/if}
       </div>
 
       <!-- Right: Language switcher + Donate -->
-      <div class="hidden items-center gap-3 md:flex">
+      <div class="flex items-center gap-3">
         <select
-          bind:value={currentLang}
-          onchange={handleLanguageChange}
-          class="rounded-lg border border-slate-200 bg-white px-2 py-1 text-xs font-semibold uppercase tracking-wide text-slate-700 shadow-sm transition-colors hover:border-[#28AF57] focus:border-[#28AF57] focus:outline-none"
+          bind:value={currentLocale}
+          on:change={handleLocaleChange}
+          class="rounded-lg border border-slate-200 bg-white px-2 py-1 text-xs font-semibold uppercase tracking-wide text-slate-700 shadow-sm transition-colors hover:border-[#2c9166] focus:border-[#2c9166] focus:outline-none"
         >
-          <option value="en">EN</option>
-          <option value="es">ES</option>
+          {#each locales as locale}
+            <option value={locale}>{locale.toUpperCase()}</option>
+          {/each}
         </select>
         <a
           href="#donate"
-          class="rounded-lg bg-[#28AF57] px-5 py-2 text-sm font-semibold text-white no-underline transition-colors hover:bg-[#229647]"
+          class="rounded-lg bg-[#2c9166] px-4 py-2 text-sm font-semibold text-white no-underline transition-colors hover:bg-[#216d4d]"
         >
           {m.home_donate_button()}
         </a>
       </div>
-
-      <!-- Mobile menu button -->
-      <button
-        type="button"
-        onclick={() => (mobileMenuOpen = !mobileMenuOpen)}
-        class="flex items-center gap-2 text-sm font-medium text-slate-700 md:hidden"
-        aria-label="Menu"
-      >
-        <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
-        </svg>
-      </button>
     </div>
-
-    <!-- Mobile menu dropdown -->
-    {#if mobileMenuOpen}
-      <nav class="border-t border-slate-200 pb-3 md:hidden">
-        <a
-          href="#search"
-          class="block px-4 py-2 text-sm font-medium text-slate-700 no-underline transition-colors hover:bg-slate-50 hover:text-[#28AF57]"
-        >
-          Search
-        </a>
-        <a
-          href="#about"
-          class="block px-4 py-2 text-sm font-medium text-slate-700 no-underline transition-colors hover:bg-slate-50 hover:text-[#28AF57]"
-        >
-          {m.home_toc_learn()}
-        </a>
-        <a
-          href="#download"
-          class="block px-4 py-2 text-sm font-medium text-slate-700 no-underline transition-colors hover:bg-slate-50 hover:text-[#28AF57]"
-        >
-          {m.home_toc_download()}
-        </a>
-      </nav>
-    {/if}
   </div>
 </header>

--- a/packages/web/src/routes/+page.svelte
+++ b/packages/web/src/routes/+page.svelte
@@ -29,7 +29,7 @@
   <title>{m.home_hero_headline()}</title>
 </svelte:head>
 
-<StickyHeader />
+<StickyHeader agencies={data.agencies} />
 
 <main class="min-h-screen bg-white">
   <!-- Hero Section -->


### PR DESCRIPTION
- Import QuickScore and implement fuzzy search functionality
- Add agencies prop to StickyHeader component
- Search results ranked by stops count then relevance
- Keyboard navigation (arrow keys, enter, escape)
- Dynamic language switcher using paraglide locales
- 