### PR TITLE
Reduce scatter card corner radius

### DIFF
--- a/packages/web/src/lib/components/AgencyRateScatter.svelte
+++ b/packages/web/src/lib/components/AgencyRateScatter.svelte
@@ -683,7 +683,7 @@
 
 </script>
 
-<div class="overflow-hidden rounded-3xl border border-slate-400 bg-white">
+<div class="overflow-hidden rounded-2xl border border-slate-400 bg-white">
   <div class="border-b border-slate-600 bg-slate-700 px-2.5 py-3 sm:px-4">
     <div class="flex items-center justify-between gap-3 sm:items-start">
       <div class="min-w-0">


### PR DESCRIPTION
## Summary
- reduce agency scatter card rounding from rounded-3xl to rounded-2xl

## Testing
- not run (style change)

closes #62
