### PR TITLE
Fix duplicate map hover layer ids

### DIFF
--- a/packages/web/src/lib/components/AgencyMap.svelte
+++ b/packages/web/src/lib/components/AgencyMap.svelte
@@ -481,7 +481,7 @@
           />
           <svelte:component
             this={LineLayer}
-            id="mo-jurisdictions-counties-hover"
+            id="mo-jurisdictions-counties-hover-outline"
             source="mo-jurisdictions"
             source-layer="counties"
             paint={hoverLinePaintCounties}
@@ -511,7 +511,7 @@
           />
           <svelte:component
             this={LineLayer}
-            id="mo-jurisdictions-places-hover"
+            id="mo-jurisdictions-places-hover-outline"
             source="mo-jurisdictions"
             source-layer="places"
             paint={hoverLinePaintPlaces}


### PR DESCRIPTION
## Summary
- give hover outline layers unique ids to avoid MapLibre duplicate layer errors

## Testing
- not run (manual fix)

closes #67
