### PR TITLE
update/ fix search sorting

### DIFF
--- a/packages/web/src/lib/components/LocationPicker.svelte
+++ b/packages/web/src/lib/components/LocationPicker.svelte
@@ -56,7 +56,7 @@
     const trimmedQuery = query.trim();
     const queryTokens = tokensFor(trimmedQuery);
     const queryNorm = normalizeText(trimmedQuery);
-    const scored = scorer.search(trimmedQuery).slice(0, 25);
+    const scored = scorer.search(trimmedQuery);
     const exactMatches = [];
     const strongMatches = [];
     const fuzzyMatches = [];

--- a/packages/web/src/lib/components/StickyHeader.svelte
+++ b/packages/web/src/lib/components/StickyHeader.svelte
@@ -65,7 +65,7 @@
     const queryNorm = trimmedQuery.toLowerCase().replace(/[^a-z0-9]+/g, " ").trim();
     const queryTokens = queryNorm.split(" ").filter(Boolean);
 
-    const scored = scorer.search(trimmedQuery).slice(0, 25);
+    const scored = scorer.search(trimmedQuery);
 
     const perfectMatches = [];
     const strongMatches = [];


### PR DESCRIPTION
- This is a slightly different/ more technical approach than before, but I realized this may be more foolproof for places with very similar names! 
- Fix search sorting so exact matches like "St Ann Police Dept" show up first when searching "st ann" instead of being buried under high-stop agencies
- Use 3-tier categorization: perfect matches → strong matches → fuzzy matches
- Perfect/exact matches sorted by stops, strong matches sorted by score, fuzzy matches sorted by stops
