### PR TITLE
fix headline

### DIFF
--- a/packages/web/src/lib/components/StickyHeader.svelte
+++ b/packages/web/src/lib/components/StickyHeader.svelte
@@ -236,7 +236,7 @@
         <div class="min-w-0">
           <a
             href="/"
-            class="min-w-0 truncate text-lg font-bold text-[#2c9166] no-underline sm:text-xl md:text-[1.45rem]"
+            class="min-w-0 font-bold text-[#2c9166] no-underline text-[clamp(0.95rem,4vw,1.45rem)] leading-tight"
           >
             {m.home_header_title()}
           </a>


### PR DESCRIPTION
Use fluid typography with clamp() so title scales with viewport width Remove truncate so text wraps instead of cutting off on very narrow screens Title now fully visible on all device widths

To be safe, lets do one more round of testing. gotta find every way to break it to guarentee its perfect!!