### PR TITLE
Homepage agencies comparison table and nav polish

### DIFF
--- a/packages/web/src/app.css
+++ b/packages/web/src/app.css
@@ -6,6 +6,7 @@
 @layer base {
   :root {
     --site-header-height: 3.5rem;
+    --site-header-anchor-offset: 7rem;
     --year-header-height: 1.75rem;
   }
 
@@ -25,6 +26,18 @@
 
   body {
     @apply bg-slate-50 font-sans text-slate-900 antialiased;
+  }
+
+  html,
+  body {
+    scroll-padding-top: var(--site-header-anchor-offset, 7rem);
+  }
+
+  #findings,
+  #agencies,
+  #download,
+  #about {
+    scroll-margin-top: var(--site-header-anchor-offset, 7rem);
   }
 
   a {
@@ -71,6 +84,7 @@
 @media (max-width: 768px) {
   :root {
     --site-header-height: 3.5rem;
+    --site-header-anchor-offset: 7rem;
   }
 }
 

--- a/packages/web/src/lib/components/AgencyMap.svelte
+++ b/packages/web/src/lib/components/AgencyMap.svelte
@@ -37,6 +37,8 @@
   let boundaryUrl = "";
   let lastBoundaryUrl = "";
   let lastBoundsKey = "";
+  let lastBoundaryRequestId = 0;
+  let isMounted = false;
   let pmtilesProtocol;
   let pmtilesReady = false;
   let pmtilesSourceUrl = "";
@@ -124,6 +126,7 @@
 
   onMount(async () => {
     if (!browser) return;
+    isMounted = true;
     const mod = await import("svelte-maplibre-gl");
     MapLibre = mod.MapLibre;
     Marker = mod.Marker;
@@ -176,6 +179,7 @@
   });
 
   onDestroy(() => {
+    isMounted = false;
     cleanupHoverHandlers();
     popup?.remove?.();
     popup = null;
@@ -201,16 +205,21 @@
     lastBoundaryUrl = "";
   }
 
-  $: if (!hasBoundaryOverride && browser && boundaryUrl && boundaryUrl !== lastBoundaryUrl) {
+  const loadBoundaryData = async (url) => {
+    const requestId = ++lastBoundaryRequestId;
+    try {
+      const response = await fetch(url);
+      if (requestId !== lastBoundaryRequestId) return;
+      boundaryData = response.ok ? await response.json() : null;
+    } catch {
+      if (requestId !== lastBoundaryRequestId) return;
+      boundaryData = null;
+    }
+  };
+
+  $: if (!hasBoundaryOverride && isMounted && boundaryUrl && boundaryUrl !== lastBoundaryUrl) {
     lastBoundaryUrl = boundaryUrl;
-    fetch(boundaryUrl)
-      .then((response) => (response.ok ? response.json() : null))
-      .then((data) => {
-        boundaryData = data;
-      })
-      .catch(() => {
-        boundaryData = null;
-      });
+    void loadBoundaryData(boundaryUrl);
   }
 
   const updateBoundaryBounds = () => {

--- a/packages/web/src/lib/components/HomeAgencyMetricTable.svelte
+++ b/packages/web/src/lib/components/HomeAgencyMetricTable.svelte
@@ -1,0 +1,982 @@
+<script lang="ts">
+  import { Grid, PagingData, PlainTableCssTheme } from "@mediakular/gridcraft";
+  import { onMount } from "svelte";
+  import { getLocale } from "$lib/paraglide/runtime.js";
+  import { withDataBase } from "$lib/dataBase";
+  import * as m from "$lib/paraglide/messages.js";
+  import GridAgencyLinkCell from "$lib/components/grid/GridAgencyLinkCell.svelte";
+
+  type AgencyIndexEntry = {
+    agency_slug?: string;
+    slug?: string;
+    id?: string;
+    canonical_name?: string;
+    agency_name?: string;
+    name?: string;
+    agency?: string;
+    names?: string[];
+  };
+
+  type BaselineEntry = {
+    row_key?: string;
+  };
+
+  type MetricFileRow = {
+    agency?: string;
+    year?: number | string;
+    Total?: number | null;
+    White?: number | null;
+    Black?: number | null;
+    Hispanic?: number | null;
+    "Native American"?: number | null;
+    Asian?: number | null;
+    Other?: number | null;
+  };
+
+  type MetricFilePayload = {
+    row_key?: string;
+    rows?: MetricFileRow[];
+  };
+
+  type MetricOption = {
+    value: string;
+    label: string;
+  };
+
+  type AgencyLink = {
+    value: string;
+    href: string;
+  };
+
+  type TableRow = {
+    id: string;
+    agency: {
+      value: string;
+      href: string;
+    };
+    total_stops: string;
+    Total: string;
+    White: string;
+    Black: string;
+    Hispanic: string;
+    "Native American": string;
+    Asian: string;
+    Other: string;
+    raw: Record<string, number>;
+  };
+
+  export let agencies: AgencyIndexEntry[] = [];
+
+  const baseTotalStopsRowKey = "rates-by-race--totals--all-stops";
+  const raceColumns = [
+    "Total",
+    "White",
+    "Black",
+    "Hispanic",
+    "Native American",
+    "Asian",
+    "Other",
+  ] as const;
+  const agencyColumnWidth = "var(--agency-col-width)";
+  const totalStopsColumnWidth = "var(--total-stops-col-width)";
+  const raceColumnWidth = "var(--race-col-width)";
+  const rateOutlierThreshold = 100;
+  const minTotalStopsPresets = [0, 100, 1000, 5000, 10000] as const;
+
+  const valueFormatter = new Intl.NumberFormat(undefined, {
+    maximumFractionDigits: 2,
+  });
+
+  const metricPayloadCache = new Map<string, Promise<MetricFilePayload>>();
+  const naturalTextSorter = new Intl.Collator(undefined, { numeric: true, sensitivity: "base" });
+
+  const compareStrings = (a: string, b: string) => (a === b ? 0 : a < b ? -1 : 1);
+
+  const normalizeText = (value: string) =>
+    value
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, " ")
+      .trim();
+
+  const toAgencySlug = (value: string) =>
+    value
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "");
+
+  const titleToken = (token: string) => {
+    const lower = token.toLowerCase();
+    if (lower === "acs") return "ACS";
+    if (lower === "bac") return "BAC";
+    if (lower === "dwi") return "DWI";
+    if (lower === "hwy") return "Hwy";
+    if (lower === "pct") return "Pct";
+    if (lower === "us") return "US";
+    return `${lower.charAt(0).toUpperCase()}${lower.slice(1)}`;
+  };
+
+  const humanizeId = (id: string) =>
+    String(id)
+      .split("-")
+      .filter(Boolean)
+      .map((token) => titleToken(token))
+      .join(" ");
+
+  const translationKeyForId = (prefix: string, id: string) =>
+    `${prefix}_${id}`
+      .replace(/[^a-z0-9]/gi, "_")
+      .replace(/_+/g, "_")
+      .replace(/^_|_$/g, "")
+      .toLowerCase();
+
+  const labelForId = (prefix: string, id: string) => {
+    if (!id) return "";
+    const key = translationKeyForId(prefix, id);
+    const labelFn = (m as Record<string, (() => string) | undefined>)[key];
+    return typeof labelFn === "function" ? labelFn() : humanizeId(id);
+  };
+
+  const metricLabelForRowKey = (rowKey: string) => {
+    const [tableId = "", sectionId = "", metricId = ""] = rowKey.split("--");
+    const tableLabel = labelForId("table", tableId) || humanizeId(tableId);
+    const sectionLabel = labelForId("section", sectionId) || humanizeId(sectionId);
+    const metricLabel = labelForId("metric", metricId) || humanizeId(metricId);
+    return `${tableLabel}: ${sectionLabel}: ${metricLabel}`;
+  };
+
+  const toDisplayValue = (value: number | null | undefined) => {
+    const numeric = typeof value === "string" ? Number(value) : value;
+    if (!Number.isFinite(numeric)) return "—";
+    return valueFormatter.format(numeric);
+  };
+
+  const toSortableNumber = (value: number | string | null | undefined) => {
+    const numeric = typeof value === "string" ? Number(value) : value;
+    return Number.isFinite(numeric) ? Number(numeric) : Number.NEGATIVE_INFINITY;
+  };
+
+  const isRateMetricRowKey = (rowKey: string) => {
+    if (!rowKey || rowKey === baseTotalStopsRowKey) return false;
+
+    const [tableId = "", sectionId = "", metricId = ""] = rowKey.split("--");
+    const section = sectionId.toLowerCase();
+    const metric = metricId.toLowerCase();
+    const table = tableId.toLowerCase();
+
+    if (section.includes("rate")) return true;
+    if (metric.includes("rate") || metric.includes("pct") || metric.includes("percent")) return true;
+    if (table.includes("rate") && section !== "totals") return true;
+    return false;
+  };
+
+  const rowHasRateOverflow = (row: TableRow) =>
+    raceColumns.some((column) => {
+      const value = row.raw[column];
+      return Number.isFinite(value) && value > rateOutlierThreshold;
+    });
+
+  const splitRowsByRateOverflow = (rows: TableRow[], hideOverflows: boolean) => {
+    if (!hideOverflows) return { visible: rows, hidden: [] as TableRow[] };
+
+    const visible: TableRow[] = [];
+    const hidden: TableRow[] = [];
+
+    rows.forEach((row) => {
+      if (rowHasRateOverflow(row)) {
+        hidden.push(row);
+      } else {
+        visible.push(row);
+      }
+    });
+
+    return { visible, hidden };
+  };
+
+  const buildAgencySlugMap = (agencyEntries: AgencyIndexEntry[]) => {
+    const map = new Map<string, string>();
+
+    agencyEntries.forEach((entry) => {
+      const slug = entry?.agency_slug || entry?.slug || entry?.id;
+      if (!slug) return;
+
+      const names = [
+        entry?.canonical_name,
+        entry?.agency_name,
+        entry?.name,
+        entry?.agency,
+        ...(Array.isArray(entry?.names) ? entry.names : []),
+      ].filter((value): value is string => Boolean(value));
+
+      names.forEach((name) => {
+        const normalized = normalizeText(name);
+        if (!normalized || map.has(normalized)) return;
+        map.set(normalized, slug);
+      });
+    });
+
+    return map;
+  };
+
+  const rowKeyOptionsFromBaselines = (baselineEntries: BaselineEntry[]) => {
+    const keys = Array.from(
+      new Set(
+        baselineEntries
+          .map((entry) => String(entry?.row_key || "").trim())
+          .filter(Boolean),
+      ),
+    );
+
+    return keys
+      .map((value) => {
+        const [tableId = "", sectionId = "", metricId = ""] = value.split("--");
+        const tableLabel = labelForId("table", tableId) || humanizeId(tableId);
+        const sectionLabel = labelForId("section", sectionId) || humanizeId(sectionId);
+        const metricLabel = labelForId("metric", metricId) || humanizeId(metricId);
+
+        return {
+          value,
+          label: `${tableLabel}: ${sectionLabel}: ${metricLabel}`,
+          tableId,
+          sectionId,
+          metricId,
+          tableLabel,
+          sectionLabel,
+          metricLabel,
+        };
+      })
+      .sort((a, b) => {
+        const tableRank = (tableId: string) => {
+          if (tableId === "rates-by-race") return 0;
+          if (tableId === "search-statistics") return 1;
+          if (tableId === "number-of-stops-by-race") return 2;
+          if (tableId === "disparity-index") return 3;
+          return 99;
+        };
+        const sectionRank = (tableId: string, sectionId: string) => {
+          if (tableId !== "rates-by-race") return 99;
+          if (sectionId === "totals") return 0;
+          if (sectionId === "rates") return 1;
+          return 2;
+        };
+
+        const tableCmp = tableRank(a.tableId) - tableRank(b.tableId);
+        if (tableCmp !== 0) return tableCmp;
+
+        const sectionPriorityCmp = sectionRank(a.tableId, a.sectionId) - sectionRank(b.tableId, b.sectionId);
+        if (sectionPriorityCmp !== 0) return sectionPriorityCmp;
+
+        const sectionCmp = naturalTextSorter.compare(a.sectionLabel, b.sectionLabel);
+        if (sectionCmp !== 0) return sectionCmp;
+
+        const metricCmp = naturalTextSorter.compare(a.metricLabel, b.metricLabel);
+        if (metricCmp !== 0) return metricCmp;
+
+        return naturalTextSorter.compare(a.value, b.value);
+      })
+      .map(({ value, label }) => ({ value, label }));
+  };
+
+  const fetchMetricPayload = async (rowKey: string) => {
+    const cached = metricPayloadCache.get(rowKey);
+    if (cached) return cached;
+
+    const request = fetch(withDataBase(`/dist/metric_year/${rowKey}.json`))
+      .then(async (response) => {
+        if (!response.ok) {
+          throw new Error(`Unable to load metric data (${response.status}).`);
+        }
+        return (await response.json()) as MetricFilePayload;
+      })
+      .catch((error) => {
+        metricPayloadCache.delete(rowKey);
+        throw error;
+      });
+
+    metricPayloadCache.set(rowKey, request);
+    return request;
+  };
+
+  const yearsFromPayload = (payload: MetricFilePayload) => {
+    const years = Array.from(
+      new Set(
+        (Array.isArray(payload?.rows) ? payload.rows : [])
+          .map((row) => String(row?.year ?? ""))
+          .filter(Boolean),
+      ),
+    );
+
+    return years.sort((a, b) => Number(b) - Number(a));
+  };
+
+  const rowsForYear = (
+    metricPayload: MetricFilePayload,
+    totalStopsPayload: MetricFilePayload,
+    year: string,
+    slugMap: Map<string, string>,
+    locale: string,
+    sortColumn: "Total" | "total_stops",
+  ): TableRow[] => {
+    const metricYearRows = (Array.isArray(metricPayload?.rows) ? metricPayload.rows : []).filter(
+      (row) => String(row?.year ?? "") === String(year),
+    );
+    const totalYearRows = (Array.isArray(totalStopsPayload?.rows) ? totalStopsPayload.rows : []).filter(
+      (row) => String(row?.year ?? "") === String(year),
+    );
+
+    const metricMap = new Map<string, MetricFileRow>();
+    metricYearRows.forEach((row) => {
+      const key = normalizeText(String(row?.agency || ""));
+      if (!key) return;
+      metricMap.set(key, row);
+    });
+
+    const totalMap = new Map<string, MetricFileRow>();
+    totalYearRows.forEach((row) => {
+      const key = normalizeText(String(row?.agency || ""));
+      if (!key) return;
+      totalMap.set(key, row);
+    });
+
+    const agencyKeys = Array.from(new Set([...metricMap.keys(), ...totalMap.keys()]));
+
+    return agencyKeys
+      .map((agencyKey) => {
+        const metricRow = metricMap.get(agencyKey);
+        const totalRow = totalMap.get(agencyKey);
+        const agencyName = String(metricRow?.agency || totalRow?.agency || "Unknown agency");
+        const agencySlug = slugMap.get(agencyKey) || toAgencySlug(agencyName);
+
+        const totalStopsRaw = toSortableNumber(totalRow?.Total);
+        const metricTotalRaw = toSortableNumber(metricRow?.Total);
+
+        const raw = {
+          total_stops: totalStopsRaw,
+          Total: metricTotalRaw,
+          White: toSortableNumber(metricRow?.White),
+          Black: toSortableNumber(metricRow?.Black),
+          Hispanic: toSortableNumber(metricRow?.Hispanic),
+          "Native American": toSortableNumber(metricRow?.["Native American"]),
+          Asian: toSortableNumber(metricRow?.Asian),
+          Other: toSortableNumber(metricRow?.Other),
+        };
+
+        return {
+          id: `${agencyName}-${year}`,
+          agency: {
+            value: agencyName,
+            href: `/${locale}/agency/${agencySlug}`,
+          },
+          total_stops: toDisplayValue(totalRow?.Total),
+          Total: toDisplayValue(metricRow?.Total),
+          White: toDisplayValue(metricRow?.White),
+          Black: toDisplayValue(metricRow?.Black),
+          Hispanic: toDisplayValue(metricRow?.Hispanic),
+          "Native American": toDisplayValue(metricRow?.["Native American"]),
+          Asian: toDisplayValue(metricRow?.Asian),
+          Other: toDisplayValue(metricRow?.Other),
+          raw,
+        };
+      })
+      .sort((a, b) => {
+        if (b.raw[sortColumn] !== a.raw[sortColumn]) return b.raw[sortColumn] - a.raw[sortColumn];
+        return compareStrings(a.agency.value, b.agency.value);
+      });
+  };
+
+  let currentLocale = "en";
+  let agencySlugMap = new Map<string, string>();
+
+  let metricOptions: MetricOption[] = [];
+  let selectedMetric = baseTotalStopsRowKey;
+  let yearOptions: string[] = [];
+  let selectedYear = "";
+  let agencySearch = "";
+
+  let isLoading = true;
+  let loadError = "";
+  let tableRows: TableRow[] = [];
+  let visibleRaceColumns: (typeof raceColumns)[number][] = [...raceColumns];
+  let defaultSortColumn = "Total";
+  let gridColumns: any[] = [];
+  let gridSortByColumn = "Total";
+  let gridSortOrder = -1;
+  let lastSortedColumn = "";
+  let sortResetMetric = "";
+  let gridFrameElement: HTMLDivElement | null = null;
+  let normalizedSearch = "";
+  let rateFilteredRows: TableRow[] = [];
+  let overflowRows: TableRow[] = [];
+  let excludedAgencyLinks: AgencyLink[] = [];
+  let minTotalStops = 100;
+  let minTotalStopsInput = "100";
+  let normalizedMinTotalStops = 100;
+  let filteredRows: TableRow[] = [];
+  let shouldHideOver100Rates = false;
+
+  const gridPaging = new PagingData(1, 1000, [1000]);
+
+  $: visibleRaceColumns =
+    selectedMetric === baseTotalStopsRowKey
+      ? (raceColumns.filter((column) => column !== "Total") as (typeof raceColumns)[number][])
+      : [...raceColumns];
+  $: defaultSortColumn = selectedMetric === baseTotalStopsRowKey ? "total_stops" : "Total";
+  $: if (selectedMetric !== sortResetMetric) {
+    gridSortByColumn = defaultSortColumn;
+    gridSortOrder = -1;
+    lastSortedColumn = defaultSortColumn;
+    sortResetMetric = selectedMetric;
+  }
+  $: if (gridSortByColumn && gridSortByColumn !== lastSortedColumn) {
+    if (gridSortOrder === 1) {
+      // Gridcraft initializes new column clicks with ascending order; flip once so first click is descending.
+      gridSortOrder = -1;
+    }
+    lastSortedColumn = gridSortByColumn;
+  }
+  $: gridColumns = [
+    {
+      key: "agency",
+      title: "Agency",
+      width: agencyColumnWidth,
+      sortable: true,
+      accessor: (row: TableRow) => row.agency,
+      sortValue: (row: TableRow) => row.agency.value,
+      renderComponent: GridAgencyLinkCell,
+    },
+    {
+      key: "total_stops",
+      title: "Total stops",
+      width: totalStopsColumnWidth,
+      sortable: true,
+      accessor: (row: TableRow) => row.total_stops,
+      sortValue: (row: TableRow) => row.raw.total_stops,
+    },
+    ...visibleRaceColumns.map((column) => ({
+      key: column,
+      title: column,
+      width: raceColumnWidth,
+      sortable: true,
+      accessor: (row: TableRow) => row[column],
+      sortValue: (row: TableRow) => row.raw[column],
+    })),
+  ];
+
+  $: {
+    try {
+      currentLocale = getLocale() || "en";
+    } catch {
+      currentLocale = "en";
+    }
+  }
+
+  $: agencySlugMap = buildAgencySlugMap(agencies || []);
+  $: shouldHideOver100Rates = isRateMetricRowKey(selectedMetric);
+  $: {
+    const split = splitRowsByRateOverflow(tableRows, shouldHideOver100Rates);
+    rateFilteredRows = split.visible;
+    overflowRows = split.hidden;
+  }
+  $: excludedAgencyLinks = Array.from(
+    new Map(overflowRows.map((row) => [row.agency.href, row.agency])).values(),
+  ).sort((a, b) => compareStrings(a.value, b.value));
+  $: normalizedMinTotalStops = Number.isFinite(Number(minTotalStops)) ? Math.max(0, Number(minTotalStops)) : 0;
+  $: normalizedSearch = normalizeText(agencySearch || "");
+  $: filteredRows = rateFilteredRows.filter((row) => {
+    if (row.raw.total_stops < normalizedMinTotalStops) return false;
+    if (!normalizedSearch) return true;
+    return normalizeText(row.agency.value).includes(normalizedSearch);
+  });
+
+  const applyMinTotalStopsInput = () => {
+    const parsed = Number(minTotalStopsInput);
+    const next = Number.isFinite(parsed) ? Math.max(0, Math.round(parsed)) : 0;
+    minTotalStops = next;
+    minTotalStopsInput = String(next);
+  };
+
+  const setMinTotalStops = (value: number) => {
+    const next = Math.max(0, Math.round(value));
+    minTotalStops = next;
+    minTotalStopsInput = String(next);
+  };
+
+  const handleMinStopsInput = (event: Event) => {
+    const target = event.currentTarget as HTMLInputElement;
+    minTotalStopsInput = target.value;
+  };
+
+  const handleMinStopsKeydown = (event: KeyboardEvent) => {
+    if (event.key !== "Enter") return;
+    event.preventDefault();
+    applyMinTotalStopsInput();
+    (event.currentTarget as HTMLInputElement)?.blur();
+  };
+
+  const loadMetricRows = async (rowKey: string, keepYear = false) => {
+    isLoading = true;
+    loadError = "";
+
+    try {
+      const [metricPayload, totalStopsPayload] = await Promise.all([
+        fetchMetricPayload(rowKey),
+        fetchMetricPayload(baseTotalStopsRowKey),
+      ]);
+
+      const years = yearsFromPayload(metricPayload);
+      yearOptions = years;
+
+      if (!keepYear || !years.includes(selectedYear)) {
+        selectedYear = years[0] ?? "";
+      }
+
+      const sortColumn = rowKey === baseTotalStopsRowKey ? "total_stops" : "Total";
+      tableRows = selectedYear
+        ? rowsForYear(
+            metricPayload,
+            totalStopsPayload,
+            selectedYear,
+            agencySlugMap,
+            currentLocale,
+            sortColumn,
+          )
+        : [];
+    } catch (error) {
+      loadError =
+        error instanceof Error ? error.message : "Unable to load selected metric data.";
+      yearOptions = [];
+      selectedYear = "";
+      tableRows = [];
+    } finally {
+      isLoading = false;
+    }
+  };
+
+  const initialize = async () => {
+    isLoading = true;
+    loadError = "";
+
+    try {
+      const response = await fetch(withDataBase("/dist/statewide_slug_baselines.json"));
+      if (!response.ok) {
+        throw new Error(`Unable to load metric list (${response.status}).`);
+      }
+
+      const baselineEntries = (await response.json()) as BaselineEntry[];
+      metricOptions = rowKeyOptionsFromBaselines(baselineEntries);
+
+      if (!metricOptions.length) {
+        throw new Error("No metrics available.");
+      }
+
+      if (!metricOptions.some((option) => option.value === selectedMetric)) {
+        selectedMetric = metricOptions[0].value;
+      }
+
+      await loadMetricRows(selectedMetric, false);
+    } catch (error) {
+      loadError =
+        error instanceof Error ? error.message : "Unable to initialize agencies table.";
+      metricOptions = [];
+      yearOptions = [];
+      selectedYear = "";
+      tableRows = [];
+      isLoading = false;
+    }
+  };
+
+  const handleMetricChange = async (event: Event) => {
+    const target = event.currentTarget as HTMLSelectElement;
+    selectedMetric = target.value;
+    await loadMetricRows(selectedMetric, false);
+  };
+
+  const selectYear = async (year: string) => {
+    selectedYear = year;
+    await loadMetricRows(selectedMetric, true);
+  };
+
+  const handleGridRowClick = (event: MouseEvent) => {
+    const rawTarget = event.target as EventTarget | null;
+    if (!rawTarget) return;
+    const target =
+      rawTarget instanceof Element ? rawTarget : (rawTarget as Node).parentElement;
+    if (!target) return;
+
+    if (target.closest("a, button, input, select, textarea, label")) {
+      return;
+    }
+
+    const row = target.closest("tbody tr");
+    if (!row) return;
+
+    const link = row.querySelector("td:first-child a[href]") as HTMLAnchorElement | null;
+    if (!link?.href) return;
+
+    window.location.assign(link.href);
+  };
+
+  onMount(() => {
+    gridFrameElement?.addEventListener("click", handleGridRowClick);
+    void initialize();
+
+    return () => {
+      gridFrameElement?.removeEventListener("click", handleGridRowClick);
+    };
+  });
+</script>
+
+<section id="agencies" class="border-t border-slate-200 bg-white py-12" aria-label="Agency metric table">
+  <div class="mx-auto max-w-6xl px-6">
+    <h2 class="mb-5 text-3xl font-bold text-slate-900">How Agencies Compare</h2>
+
+    <div class="mb-5 grid grid-cols-1 gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(360px,440px)] lg:items-start">
+      <div class="min-w-0">
+        <label class="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500" for="home-metric-select">
+          Metric
+        </label>
+        <select
+          id="home-metric-select"
+          class="mt-2 h-12 w-full rounded-md border border-slate-400 bg-white px-3 text-base font-semibold text-slate-900 focus:border-slate-500 focus:outline-none"
+          bind:value={selectedMetric}
+          on:change={handleMetricChange}
+          disabled={!metricOptions.length || isLoading}
+        >
+          {#each metricOptions as option}
+            <option value={option.value}>{option.label}</option>
+          {/each}
+        </select>
+        <p class="mt-2 pl-1 text-[0.72rem] font-medium text-slate-500 sm:text-xs">
+          Showing {filteredRows.length.toLocaleString()} agencies (out of {rateFilteredRows.length.toLocaleString()}).
+        </p>
+      </div>
+
+      <div class="min-w-0">
+        <label class="text-[0.65rem] font-semibold uppercase tracking-[0.12em] text-slate-500" for="home-min-stops">
+          Min total stops
+        </label>
+        <input
+          id="home-min-stops"
+          type="number"
+          min="0"
+          step="100"
+          class="mt-2 h-11 w-full rounded-md border border-slate-400 bg-white px-3 text-base text-slate-700 focus:border-slate-500 focus:outline-none"
+          value={minTotalStopsInput}
+          on:input={handleMinStopsInput}
+          on:change={applyMinTotalStopsInput}
+          on:blur={applyMinTotalStopsInput}
+          on:keydown={handleMinStopsKeydown}
+        />
+        <div class="mt-2 flex flex-wrap gap-1.5">
+          {#each minTotalStopsPresets as preset}
+            <button
+              type="button"
+              class={`rounded-md border px-3 py-1.5 text-xs font-semibold leading-none transition sm:text-sm ${
+                minTotalStops === preset
+                  ? "border-slate-900 bg-slate-900 text-white"
+                  : "border-slate-300 bg-white text-slate-600 hover:border-slate-400 hover:text-slate-900"
+              }`}
+              on:click={() => setMinTotalStops(preset)}
+            >
+              {preset.toLocaleString()}
+            </button>
+          {/each}
+        </div>
+      </div>
+    </div>
+
+    <div class="mb-5">
+      <input
+        type="search"
+        class="h-10 w-full rounded-md border border-slate-400 bg-white px-2.5 text-sm text-slate-700 placeholder:text-slate-500 focus:border-slate-500 focus:outline-none sm:w-80 md:w-96"
+        placeholder='Search table for an agency ("St. Louis", "Springfield")'
+        aria-label="Search agencies"
+        bind:value={agencySearch}
+      />
+    </div>
+
+    {#if yearOptions.length}
+      <div role="tablist" aria-label="Year selector" class="mb-5 mt-2 flex flex-wrap items-center gap-2">
+        {#each yearOptions as year}
+          <button
+            type="button"
+            role="tab"
+            aria-selected={year === selectedYear}
+            class={`rounded-md border px-3 py-1.5 text-sm font-semibold tracking-wide transition sm:text-base ${
+              year === selectedYear
+                ? "border-slate-900 bg-slate-900 text-white"
+                : "border-slate-200 bg-white text-slate-600 hover:border-slate-300 hover:text-slate-900"
+            }`}
+            on:click={() => selectYear(year)}
+            disabled={isLoading}
+          >
+            {year}
+          </button>
+        {/each}
+      </div>
+    {/if}
+
+    {#if loadError}
+      <p class="rounded-md border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">
+        {loadError}
+      </p>
+    {/if}
+
+    <div class="agency-metric-grid agency-metric-grid--frame" bind:this={gridFrameElement}>
+      {#if filteredRows.length}
+        <Grid
+          data={filteredRows}
+          columns={gridColumns}
+          paging={gridPaging}
+          theme={PlainTableCssTheme}
+          bind:sortByColumn={gridSortByColumn}
+          bind:sortOrder={gridSortOrder}
+        />
+      {:else if !isLoading}
+        <div class="agency-metric-grid__empty">No rows found for this metric/year.</div>
+      {/if}
+
+      {#if isLoading}
+        <div class="agency-metric-grid__overlay">
+          <span>Loading metric data...</span>
+        </div>
+      {/if}
+    </div>
+
+    {#if excludedAgencyLinks.length}
+      <div class="mt-2 text-[0.72rem] leading-relaxed text-slate-500 sm:text-xs">
+        <p>
+          Hidden for values over 100%:
+          {#each excludedAgencyLinks as agency, index}
+            <a
+              class="text-slate-600 no-underline transition-colors hover:text-slate-800 hover:underline"
+              href={agency.href}
+            >
+              {agency.value}</a
+            >{index < excludedAgencyLinks.length - 1 ? ", " : "."}
+          {/each}
+        </p>
+      </div>
+    {/if}
+
+  </div>
+</section>
+
+<style>
+  .agency-metric-grid {
+    --agency-col-width: 140px;
+    --total-stops-col-width: 92px;
+    --race-col-width: 110px;
+    --sticky-col-bg: #f8fafc;
+    --sticky-col-hover-bg: #e2e8f0;
+    --gc-th-font-size: 0.62rem;
+    --gc-th-color: #ffffff;
+  }
+
+  :global(.agency-metric-grid .gc-table-wrapper) {
+    overflow: auto;
+    height: min(70vh, 900px);
+    position: relative;
+  }
+
+  .agency-metric-grid--frame {
+    position: relative;
+    min-height: min(70vh, 900px);
+  }
+
+  .agency-metric-grid__empty {
+    display: grid;
+    place-items: center;
+    min-height: min(70vh, 900px);
+    border: 1px solid #e2e8f0;
+    border-radius: 0.375rem;
+    background: #f8fafc;
+    color: #475569;
+    font-size: 0.9rem;
+  }
+
+  .agency-metric-grid__overlay {
+    position: absolute;
+    inset: 0;
+    display: grid;
+    place-items: center;
+    background: rgba(255, 255, 255, 0.72);
+    color: #334155;
+    font-size: 0.9rem;
+    font-weight: 600;
+    pointer-events: none;
+    backdrop-filter: blur(1px);
+  }
+
+  :global(.agency-metric-grid .gc-table) {
+    border-collapse: collapse;
+    border-spacing: 0;
+    width: 100%;
+    table-layout: fixed;
+  }
+
+  :global(.agency-metric-grid .gc-header-tr th) {
+    position: sticky;
+    top: 0;
+    z-index: 3;
+    background: #334155;
+    border-color: #334155;
+    color: var(--gc-th-color);
+    cursor: default;
+    font-size: var(--gc-th-font-size);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    padding: 0.5rem 0.45rem;
+    line-height: 1.1;
+  }
+
+  :global(.agency-metric-grid .gc-header-tr .gc-th-col-title) {
+    color: var(--gc-th-color);
+    font-size: var(--gc-th-font-size);
+  }
+
+  :global(.agency-metric-grid .gc-header-tr th *) {
+    color: inherit;
+  }
+
+  :global(.agency-metric-grid .gc-header-tr .gc-th-col) {
+    position: relative;
+    padding-right: 0.95rem;
+  }
+
+  :global(.agency-metric-grid .gc-header-tr .gc-th-col svg) {
+    position: absolute;
+    right: 0;
+    top: 50%;
+  }
+
+  :global(.agency-metric-grid .gc-header-tr .gc-th-col .lucide-arrow-down),
+  :global(.agency-metric-grid .gc-header-tr .gc-th-col .lucide-arrow-up) {
+    transform: translateY(-50%) rotate(180deg);
+  }
+
+  :global(.agency-metric-grid .gc-table th:first-child) {
+    left: 0;
+    z-index: 6;
+  }
+
+  :global(.agency-metric-grid .gc-table th:nth-child(2)) {
+    left: var(--agency-col-width);
+    z-index: 5;
+  }
+
+  :global(.agency-metric-grid .gc-header-tr th:has(.lucide-arrow-down)),
+  :global(.agency-metric-grid .gc-header-tr th:has(.lucide-arrow-up)) {
+    background: #1f2937;
+    border-color: #1f2937;
+  }
+
+  :global(.agency-metric-grid .gc-table th),
+  :global(.agency-metric-grid .gc-table td) {
+    border: 0;
+  }
+
+  :global(.agency-metric-grid .gc-table td) {
+    background: #ffffff;
+    padding: 0.5rem 0.45rem;
+    font-size: 0.8rem;
+    color: #0f172a;
+  }
+
+  :global(.agency-metric-grid .gc-table td:not(:first-child)) {
+    font-variant-numeric: tabular-nums;
+    padding-left: 0.22rem;
+    padding-right: 0.22rem;
+  }
+
+  :global(.agency-metric-grid .gc-table th:not(:first-child)) {
+    text-align: center;
+    padding-left: 0.22rem;
+    padding-right: 0.22rem;
+  }
+
+  :global(.agency-metric-grid .gc-table th:not(:first-child) .gc-th-col) {
+    justify-content: center;
+  }
+
+  :global(.agency-metric-grid .gc-table td:not(:first-child)) {
+    text-align: right;
+  }
+
+  :global(.agency-metric-grid .gc-table tbody tr:hover td) {
+    background: #f1f5f9;
+  }
+
+  :global(.agency-metric-grid .gc-table tbody tr) {
+    cursor: pointer;
+  }
+
+  :global(.agency-metric-grid .gc-table td:first-child) {
+    position: sticky;
+    left: 0;
+    z-index: 4;
+    background: var(--sticky-col-bg);
+    white-space: normal;
+    overflow-wrap: anywhere;
+    box-shadow: 6px 0 8px -6px rgba(15, 23, 42, 0.15);
+  }
+
+  :global(.agency-metric-grid .gc-table td:nth-child(2)) {
+    position: sticky;
+    left: var(--agency-col-width);
+    z-index: 3;
+    background: var(--sticky-col-bg);
+    box-shadow: 6px 0 8px -6px rgba(15, 23, 42, 0.15);
+  }
+
+  :global(.agency-metric-grid .gc-table tbody tr:hover td:first-child) {
+    background: var(--sticky-col-hover-bg);
+  }
+
+  :global(.agency-metric-grid .gc-table tbody tr:hover td:nth-child(2)) {
+    background: var(--sticky-col-hover-bg);
+  }
+
+  @media (max-width: 640px) {
+    .agency-metric-grid {
+      --agency-col-width: 102px;
+      --total-stops-col-width: 78px;
+      --race-col-width: 78px;
+      --gc-th-font-size: 0.6rem;
+    }
+
+    .agency-metric-grid--frame {
+      width: 100vw;
+      margin-left: calc(50% - 50vw);
+      margin-right: calc(50% - 50vw);
+    }
+
+    :global(.agency-metric-grid .gc-table-wrapper) {
+      height: min(74vh, 760px);
+    }
+
+    :global(.agency-metric-grid .gc-header-tr th) {
+      letter-spacing: 0.04em;
+      padding: 0.3rem 0.35rem;
+    }
+
+    :global(.agency-metric-grid .gc-table td) {
+      font-size: 0.74rem;
+      padding: 0.42rem 0.35rem;
+    }
+
+    :global(.agency-metric-grid .gc-table td:not(:first-child)) {
+      padding-left: 0.24rem !important;
+      padding-right: 0.24rem !important;
+    }
+
+    :global(.agency-metric-grid .gc-table th:not(:first-child)) {
+      padding-left: 0.24rem !important;
+      padding-right: 0.24rem !important;
+    }
+
+    :global(.agency-metric-grid .gc-header-tr th:nth-child(n + 3) .gc-th-col) {
+      gap: 0.1rem;
+      padding-right: 0.5rem;
+    }
+  }
+</style>

--- a/packages/web/src/lib/components/StickyHeader.svelte
+++ b/packages/web/src/lib/components/StickyHeader.svelte
@@ -64,9 +64,14 @@
   }
 
   $: if (headerHeight && typeof document !== "undefined") {
+    const measuredHeight = Math.ceil(headerHeight);
     document.documentElement.style.setProperty(
       "--site-header-height",
-      `${headerHeight}px`
+      `${measuredHeight}px`
+    );
+    document.documentElement.style.setProperty(
+      "--site-header-anchor-offset",
+      `${measuredHeight + 24}px`
     );
   }
 
@@ -429,12 +434,20 @@
           {/if}
         </div>
         <nav class="hidden items-center justify-end gap-2.5 text-sm md:flex">
+          <a href={`${localeBase}/#findings`} class="font-semibold text-[#1b613c] no-underline hover:text-[#105430]">
+            Findings
+          </a>
+          <span class="text-slate-300">•</span>
+          <a href={`${localeBase}/#agencies`} class="font-semibold text-[#1b613c] no-underline hover:text-[#105430]">
+            Agencies
+          </a>
+          <span class="text-slate-300">•</span>
           <a href={`${localeBase}/#download`} class="font-semibold text-[#1b613c] no-underline hover:text-[#105430]">
-            {m.home_toc_download()}
+            Download
           </a>
           <span class="text-slate-300">•</span>
           <a href={`${localeBase}/#about`} class="font-semibold text-[#1b613c] no-underline hover:text-[#105430]">
-            {m.home_toc_learn()}
+            About
           </a>
         </nav>
       </div>
@@ -462,18 +475,32 @@
         <p class="mt-8 text-xs font-semibold uppercase tracking-[0.22em] text-slate-500">Explore</p>
         <nav class="mt-3 space-y-3">
           <a
+            href={`${localeBase}/#findings`}
+            class="block text-3xl font-semibold leading-tight text-slate-900 no-underline"
+            on:click={() => closeMenu("nav")}
+          >
+            Findings
+          </a>
+          <a
+            href={`${localeBase}/#agencies`}
+            class="block text-3xl font-semibold leading-tight text-slate-900 no-underline"
+            on:click={() => closeMenu("nav")}
+          >
+            Agencies
+          </a>
+          <a
             href={`${localeBase}/#download`}
             class="block text-3xl font-semibold leading-tight text-slate-900 no-underline"
             on:click={() => closeMenu("nav")}
           >
-            {m.home_toc_download()}
+            Download
           </a>
           <a
             href={`${localeBase}/#about`}
             class="block text-3xl font-semibold leading-tight text-slate-900 no-underline"
             on:click={() => closeMenu("nav")}
           >
-            {m.home_toc_learn()}
+            About
           </a>
         </nav>
 

--- a/packages/web/src/lib/components/grid/GridAgencyLinkCell.svelte
+++ b/packages/web/src/lib/components/grid/GridAgencyLinkCell.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+  export let value: string | { value?: string; href?: string } | null | undefined = "";
+  export let href: string | null | undefined = undefined;
+
+  let label = "—";
+  let resolvedHref = "";
+
+  $: {
+    if (value && typeof value === "object") {
+      label = value.value ? String(value.value) : "—";
+      resolvedHref = href ? String(href) : value.href ? String(value.href) : "";
+    } else {
+      label = value === null || value === undefined || value === "" ? "—" : String(value);
+      resolvedHref = href ? String(href) : "";
+    }
+  }
+</script>
+
+{#if resolvedHref}
+  <a
+    class="block whitespace-normal text-[0.72rem] font-semibold leading-snug text-emerald-900 no-underline transition-colors hover:text-emerald-700 hover:no-underline sm:text-sm"
+    href={resolvedHref}
+  >
+    {label}
+  </a>
+{:else}
+  <span class="block whitespace-normal text-[0.72rem] font-semibold leading-snug text-slate-700 sm:text-sm">
+    {label}
+  </span>
+{/if}

--- a/packages/web/src/routes/+layout.svelte
+++ b/packages/web/src/routes/+layout.svelte
@@ -6,8 +6,19 @@
   export let data;
 
   const fallbackUmamiWebsiteId = import.meta.env.PUBLIC_UMAMI_WEBSITE_ID ?? null;
+  const normalizePath = (pathname) => {
+    const normalized = String(pathname || "/").replace(/\/+$/, "");
+    return normalized || "/";
+  };
+
   $: umamiWebsiteId = data?.umamiWebsiteId ?? fallbackUmamiWebsiteId;
-  $: isNavigating = Boolean($navigating);
+  $: fromPath = normalizePath($navigating?.from?.url?.pathname);
+  $: toPath = normalizePath($navigating?.to?.url?.pathname);
+  $: fromRouteId = $navigating?.from?.route?.id ?? null;
+  $: toRouteId = $navigating?.to?.route?.id ?? null;
+  $: shouldFadeForNavigation =
+    Boolean($navigating) && (fromPath !== toPath || fromRouteId !== toRouteId);
+  $: isNavigating = shouldFadeForNavigation;
 </script>
 
 <svelte:head>

--- a/packages/web/src/routes/+page.svelte
+++ b/packages/web/src/routes/+page.svelte
@@ -1,5 +1,6 @@
 <script>
   import StickyHeader from "$lib/components/StickyHeader.svelte";
+  import HomeAgencyMetricTable from "$lib/components/HomeAgencyMetricTable.svelte";
   import * as m from "$lib/paraglide/messages";
   import { raceColors, raceTextColors, outcomeColors } from "$lib/colors.js";
   import { withDataBase } from "$lib/dataBase";
@@ -193,7 +194,7 @@
   </section>
 
   <!-- Highlights Grid -->
-  <section class="border-t border-slate-200 bg-slate-50 py-12">
+  <section id="findings" class="border-t border-slate-200 bg-slate-50 py-12">
     <div class="mx-auto max-w-6xl px-6">
       <h2 class="mb-8 text-center text-3xl font-bold text-slate-900">
         {m.home_highlights_heading()}
@@ -571,6 +572,8 @@
       </div>
     </div>
   </section>
+
+  <HomeAgencyMetricTable agencies={data.agencies} />
 
   <!-- Download Section -->
   <section id="download" class="border-t border-slate-200 bg-white py-12">


### PR DESCRIPTION
## Summary
- add homepage "How Agencies Compare" agency table with sortable columns, sticky key columns, and mobile styling
- add metric/year/search/min-stops controls, result counts, and rate-over-100 filtering with disclosure links
- fix agency row/cell navigation behavior and remove unwanted link underlines
- polish sticky nav jump-link behavior to avoid fade flash on hash-only navigation

closes #142
