### PR TITLE
Polish homepage numeric typography and agency-table mobile width

### DIFF
--- a/packages/web/src/lib/components/HomeAgencyMetricTable.svelte
+++ b/packages/web/src/lib/components/HomeAgencyMetricTable.svelte
@@ -884,6 +884,7 @@
 
   :global(.agency-metric-grid .gc-table td:not(:first-child)) {
     font-variant-numeric: tabular-nums;
+    font-family: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
     padding-left: 0.22rem;
     padding-right: 0.22rem;
   }

--- a/packages/web/src/routes/agency/[slug]/+layout.svelte
+++ b/packages/web/src/routes/agency/[slug]/+layout.svelte
@@ -1305,7 +1305,7 @@
         {#if metricGroups.length === 0}
           <p class="mt-4 text-sm text-slate-500">{agency_no_rows()}</p>
         {:else}
-          <div class="mb-6 max-w-full overflow-visible md:mx-[calc(50%-50vw+2rem)] md:w-[calc(100vw-4rem)] md:max-w-none">
+          <div class="mb-6 max-w-full overflow-visible">
             <div class="mt-4">
               <div class="text-2xl font-semibold text-slate-900 sm:text-3xl">
                 Annual vehicle stops statistics
@@ -1368,7 +1368,7 @@
               />
             </div>
             <div
-              class="gridcraft-table"
+              class="gridcraft-table agency-gridcraft-table--frame"
               bind:this={gridTableEl}
               style="
                 --gc-main-color: #ffffff;
@@ -1954,5 +1954,13 @@
 
   :global(.gridcraft-table .gc-td__groupby-count) {
     display: none;
+  }
+
+  @media (max-width: 640px) {
+    .agency-gridcraft-table--frame {
+      width: 100vw;
+      margin-left: calc(50% - 50vw);
+      margin-right: calc(50% - 50vw);
+    }
   }
 </style>


### PR DESCRIPTION
## Summary
- apply monospace font stack to homepage agency-table numeric columns
- switch agency-page table width treatment to mobile full-bleed only (matching homepage behavior)
- remove prior desktop-only full-width wrapper treatment on agency page table section

## Validation
- `pnpm -F web build`
