### PR TITLE
Fix locale canonical/hreflang URLs and sitemap alternates

### DIFF
--- a/packages/web/src/routes/+page.svelte
+++ b/packages/web/src/routes/+page.svelte
@@ -4,6 +4,7 @@
   import * as m from "$lib/paraglide/messages";
   import { raceColors, raceTextColors, outcomeColors } from "$lib/colors.js";
   import { withDataBase } from "$lib/dataBase";
+  import { getLocale } from "$lib/paraglide/runtime";
 
   export let data;
 
@@ -24,6 +25,19 @@
   };
 
   const siteUrl = import.meta.env.PUBLIC_SITE_URL ?? "https://vsr.recoveredfactory.net";
+  let locale = "en";
+  let localeBase = "/en";
+  $: {
+    try {
+      locale = getLocale() || "en";
+    } catch {
+      locale = "en";
+    }
+    localeBase = `/${locale}`;
+  }
+  $: canonicalUrl = `${siteUrl}${localeBase}`;
+  $: homeHrefEn = `${siteUrl}/en`;
+  $: homeHrefEs = `${siteUrl}/es`;
   const downloadManifest = data?.downloadManifest;
 
   const downloadGroupMeta = {
@@ -151,12 +165,16 @@
 
 <svelte:head>
   <title>Missouri Vehicle Stops</title>
+  <link rel="canonical" href={canonicalUrl} />
+  <link rel="alternate" hreflang="en" href={homeHrefEn} />
+  <link rel="alternate" hreflang="es" href={homeHrefEs} />
+  <link rel="alternate" hreflang="x-default" href={homeHrefEn} />
   <meta
     name="description"
     content="Who gets stopped? why? What happens next? This tool reveals how traffic enforcement varies across Missouri's agencies."
   />
   <meta property="og:type" content="website" />
-  <meta property="og:url" content="{siteUrl}/" />
+  <meta property="og:url" content={canonicalUrl} />
   <meta property="og:site_name" content="Missouri Vehicle Stops Report" />
   <meta property="og:title" content="Missouri Vehicle Stops" />
   <meta

--- a/packages/web/src/routes/agency/[slug]/+layout.svelte
+++ b/packages/web/src/routes/agency/[slug]/+layout.svelte
@@ -89,6 +89,7 @@
   let commentHeading = "";
   let noCommentText = "";
   const scatterExcludedAgencies = ["Missouri State Highway Patrol"];
+  const siteUrl = import.meta.env.PUBLIC_SITE_URL ?? "https://vsr.recoveredfactory.net";
 
   const trackEvent = (event, payload = {}) => {
     if (typeof window === "undefined") return;
@@ -144,6 +145,9 @@
     localeBase = `/${locale || "en"}`;
     basemapStyleUrl = `/map/style.${locale}.json`;
   }
+  $: canonicalAgencyUrl = `${siteUrl}${localeBase}/agency/${data.slug}`;
+  $: agencyHrefEn = `${siteUrl}/en/agency/${data.slug}`;
+  $: agencyHrefEs = `${siteUrl}/es/agency/${data.slug}`;
 
   $: years = Object.keys(rowsByYear).sort((a, b) => {
     const numA = Number(a);
@@ -427,7 +431,6 @@
   let stopVolumeSegmentSuffix = "";
   let stopVolumeRankClause = "";
   let stopVolumeStopsDisplay = "";
-  const siteUrl = import.meta.env.PUBLIC_SITE_URL ?? "https://vsr.recoveredfactory.net";
   let metaTitle = "";
   let metaDescription = "";
   const formatPhone = (value) => {
@@ -1051,9 +1054,13 @@
 
 <svelte:head>
   <title>{metaTitle}</title>
+  <link rel="canonical" href={canonicalAgencyUrl} />
+  <link rel="alternate" hreflang="en" href={agencyHrefEn} />
+  <link rel="alternate" hreflang="es" href={agencyHrefEs} />
+  <link rel="alternate" hreflang="x-default" href={agencyHrefEn} />
   <meta name="description" content={metaDescription} />
   <meta property="og:type" content="article" />
-  <meta property="og:url" content="{siteUrl}/agency/{data.slug}" />
+  <meta property="og:url" content={canonicalAgencyUrl} />
   <meta property="og:site_name" content="Missouri Vehicle Stops" />
   <meta property="og:title" content={metaTitle} />
   <meta property="og:description" content={metaDescription} />

--- a/packages/web/src/routes/sitemap.xml/+server.js
+++ b/packages/web/src/routes/sitemap.xml/+server.js
@@ -1,9 +1,10 @@
 const BASE_URL = import.meta.env.PUBLIC_SITE_URL || "https://vsr.recoveredfactory.net";
 
 function urlEntry(path) {
-  const en = `${BASE_URL}/en${path}`;
-  const es = `${BASE_URL}/es${path}`;
-  const xDefault = `${BASE_URL}${path}`;
+  const suffix = path === "/" ? "" : path;
+  const en = `${BASE_URL}/en${suffix}`;
+  const es = `${BASE_URL}/es${suffix}`;
+  const xDefault = en;
   return `  <url>
     <loc>${en}</loc>
     <xhtml:link rel="alternate" hreflang="en" href="${en}"/>


### PR DESCRIPTION
## Summary
- emit non-redirect locale URLs in sitemap home entries (`/en`, `/es`)
- set `x-default` alternates to the English locale URLs
- add canonical + hreflang tags for localized home and agency pages
- align `og:url` with localized canonical URLs
