### PR TITLE
Fix robots.txt domain, open AI crawlers, simplify sitemap

### DIFF
--- a/packages/web/src/routes/sitemap.xml/+server.js
+++ b/packages/web/src/routes/sitemap.xml/+server.js
@@ -3,13 +3,8 @@ const BASE_URL = import.meta.env.PUBLIC_SITE_URL || "https://vsr.recoveredfactor
 function urlEntry(path) {
   const suffix = path === "/" ? "" : path;
   const en = `${BASE_URL}/en${suffix}`;
-  const es = `${BASE_URL}/es${suffix}`;
-  const xDefault = en;
   return `  <url>
     <loc>${en}</loc>
-    <xhtml:link rel="alternate" hreflang="en" href="${en}"/>
-    <xhtml:link rel="alternate" hreflang="es" href="${es}"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="${xDefault}"/>
   </url>`;
 }
 
@@ -26,8 +21,7 @@ export async function GET({ fetch }) {
   }
 
   const xml = `<?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
-        xmlns:xhtml="http://www.w3.org/1999/xhtml">
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 ${urls.join("\n")}
 </urlset>
 `;

--- a/packages/web/static/robots.txt
+++ b/packages/web/static/robots.txt
@@ -1,5 +1,5 @@
 # robots.txt for Missouri Vehicle Stop Report (VSR) Tool
-# https://vsr.grupovisual.org
+# https://vsr.recoveredfactory.net
 # Last updated: 2025
 #
 # This file controls how search engines and other bots crawl this site.
@@ -148,104 +148,65 @@ User-agent: TelegramBot
 Allow: /
 
 # =============================================================================
-# AI/LLM CRAWLERS - Block AI training data collection
+# AI/LLM CRAWLERS - Allow all (public interest data, training welcome)
 # =============================================================================
 
-# OpenAI / ChatGPT
 User-agent: GPTBot
-Disallow: /
+Allow: /
 
 User-agent: ChatGPT-User
-Disallow: /
+Allow: /
 
-# Google AI (Bard/Gemini training)
+User-agent: OAI-SearchBot
+Allow: /
+
 User-agent: Google-Extended
-Disallow: /
+Allow: /
 
-# Common Crawl (used for AI training datasets)
 User-agent: CCBot
-Disallow: /
+Allow: /
 
-# Anthropic
 User-agent: anthropic-ai
-Disallow: /
+Allow: /
 
 User-agent: Claude-Web
-Disallow: /
+Allow: /
 
-# Cohere
 User-agent: cohere-ai
-Disallow: /
+Allow: /
 
-# Meta AI
 User-agent: FacebookBot
-Disallow: /
+Allow: /
 
-# Perplexity AI
 User-agent: PerplexityBot
-Disallow: /
+Allow: /
 
-# ByteDance / TikTok AI
 User-agent: Bytespider
-Disallow: /
+Allow: /
 
-# Apple AI (Applebot-Extended for AI training)
 User-agent: Applebot-Extended
-Disallow: /
+Allow: /
 
-# Amazon AI
 User-agent: Amazonbot
-Disallow: /
+Allow: /
 
-# Omgili / Webz.io (data mining)
 User-agent: omgili
-Disallow: /
+Allow: /
 
 User-agent: omgilibot
-Disallow: /
-
-# Diffbot (AI data extraction)
-User-agent: Diffbot
-Disallow: /
-
-# YouChat / You.com
-User-agent: YouBot
-Disallow: /
-
-# Neeva AI (now part of Snowflake)
-User-agent: NeevaBot
-Disallow: /
-
-# Siri/Apple Knowledge
-User-agent: Applebot
 Allow: /
-# But block extended AI training
-User-agent: Applebot-Extended
-Disallow: /
 
-# AI21 Labs
+User-agent: Diffbot
+Allow: /
+
+User-agent: YouBot
+Allow: /
+
 User-agent: AI2Bot
-Disallow: /
+Allow: /
 
-# Hugging Face dataset collection
 User-agent: HuggingFaceBot
-Disallow: /
-
-# Writesonic / other AI writing tools
-User-agent: Writesonicbot
-Disallow: /
-
-# Jasper AI
-User-agent: JasperBot
-Disallow: /
-
-# Copy.ai
-User-agent: CopyaiBot
-Disallow: /
-
-# Scrapy-based AI scrapers (generic)
-User-agent: Scrapy
-Disallow: /
+Allow: /
 
 # =============================================================================
 # SEO/RESEARCH CRAWLERS - Allow with restrictions
@@ -490,13 +451,13 @@ Allow: /
 # SITEMAP
 # =============================================================================
 
-Sitemap: https://vsr.grupovisual.org/sitemap.xml
+Sitemap: https://vsr.recoveredfactory.net/sitemap.xml
 
 # =============================================================================
 # HOST DIRECTIVE (for Yandex and others)
 # =============================================================================
 
-Host: https://vsr.grupovisual.org
+Host: https://vsr.recoveredfactory.net
 
 # =============================================================================
 # CRAWL RATE LIMITS
@@ -540,12 +501,12 @@ Clean-param: fbclid&gclid&msclkid&ref&source
 # - /map/*.pmtiles (map vector tiles)
 # - /_app/* (SvelteKit build assets)
 #
-# For questions: https://github.com/eads/missouri-vsr-tool
+# For questions: https://github.com/recoveredfactory/missouri-vsr-tool
 #
 # =============================================================================
 # CONTACT
 # =============================================================================
 #
 # If you're a legitimate crawler being blocked incorrectly, please open
-# an issue at: https://github.com/eads/missouri-vsr-tool/issues
+# an issue at: https://github.com/recoveredfactory/missouri-vsr-tool/issues
 #


### PR DESCRIPTION
## Summary

- **robots.txt**: Fix `Sitemap:` and `Host:` directives still pointing to old `vsr.grupovisual.org` — this was the primary reason only 47/600+ agency pages were indexed (crawlers were reading the wrong sitemap)
- **robots.txt**: Allow all AI crawlers — this is public interest data and training on it is welcome
- **sitemap.xml**: Drop ES `hreflang` alternates since Spanish isn't live yet; this eliminates the "Alternate page with proper canonical tag" noise in Google Search Console and stops wasting crawl budget on duplicate ES URLs

## Next steps after merge

- Re-submit sitemap in Google Search Console (`https://vsr.recoveredfactory.net/sitemap.xml`)
- Request re-indexing of the homepage in GSC to pick up the corrected robots.txt
- Perplexity sitemap submission: https://www.perplexity.ai/settings/publisher (no OpenAI equivalent yet)

closes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)