### PR TITLE
Improve meta descriptions for SEO

### DIFF
--- a/packages/web/src/routes/+page.svelte
+++ b/packages/web/src/routes/+page.svelte
@@ -175,7 +175,7 @@
 </script>
 
 <svelte:head>
-  <title>{siteName}</title>
+  <title>Missouri Vehicle Stops — Traffic Stop Data 2020–2024</title>
   <meta name="application-name" content={siteName} />
   <meta name="apple-mobile-web-app-title" content={siteName} />
   <link rel="canonical" href={canonicalUrl} />

--- a/packages/web/src/routes/agency/[slug]/+layout.svelte
+++ b/packages/web/src/routes/agency/[slug]/+layout.svelte
@@ -922,7 +922,7 @@
 
   $: {
     const agencyName = agencyData?.agency ?? data.slug;
-    metaTitle = `Missouri Vehicle Stops - ${agencyName}`;
+    metaTitle = `${agencyName} — Missouri Traffic Stop Data 2020–2024`;
     if (agencyName && stopVolumeStopsDisplay && stopVolumeSegmentLabel) {
       metaDescription = `${agencyName} made ${stopVolumeStopsDisplay} traffic stops, ranking in the ${stopVolumeSegmentLabel} of Missouri agencies. View stop demographics, search rates, and arrest outcomes.`;
     } else {


### PR DESCRIPTION
 Summary

Improve meta descriptions for SEO

Add keyword-rich, informative meta descriptions to improve Google search result snippets. Fix homepage typo ("why?" lowercase) and deduplicate the description string across meta/OG/Twitter tags.

- Replace vague homepage meta description with keyword-rich text covering data scope (400+ agencies, 2020–2024) and key metrics (stops, arrests, search rates, racial disparities)
- Extract homepage description into a `homeDescription` const to eliminate 3x duplication across meta, OG, and Twitter tags
- Improve agency page descriptions to highlight available data (demographics, search rates, arrest outcomes) instead of generic "Learn more" language
- Fix lowercase "why?" typo in old homepage description

also made so that the agency name now leads the title (best for SEO — the unique part comes first), followed by descriptive keywords and the data range 