### PR TITLE
Add JSON-LD structured data to agency pages

### DIFF
--- a/packages/web/src/routes/agency/[slug]/+layout.svelte
+++ b/packages/web/src/routes/agency/[slug]/+layout.svelte
@@ -1322,6 +1322,32 @@
   <meta property="twitter:image" content="{siteUrl}/social-meta.png" />
   <meta property="twitter:title" content={metaTitle} />
   <meta property="twitter:description" content={metaDescription} />
+  {@html `<script type="application/ld+json">${JSON.stringify({
+    "@context": "https://schema.org",
+    "@type": "Dataset",
+    name: `${agencyData?.agency ?? data.slug} — Traffic Stop Data`,
+    description: metaDescription,
+    url: canonicalAgencyUrl,
+    license: "https://www.missouri.gov/",
+    temporalCoverage: "2020/2024",
+    spatialCoverage: {
+      "@type": "Place",
+      name: [agencyData?.agency, jurisdictionDisplay, "Missouri"].filter(Boolean).join(", ")
+    },
+    publisher: {
+      "@type": "Organization",
+      name: "Recovered Factory",
+      url: "https://recoveredfactory.net"
+    },
+    isBasedOn: {
+      "@type": "CreativeWork",
+      name: "Missouri Vehicle Stops Report",
+      creator: {
+        "@type": "GovernmentOrganization",
+        name: "Missouri Attorney General"
+      }
+    }
+  })}</script>`}
 </svelte:head>
 
 <StickyHeader


### PR DESCRIPTION
Add Dataset schema.org markup to agency detail pages for richer Google search results. Uses existing page data — no new fetching.

## Summary
- Add `Dataset` JSON-LD schema to agency detail pages
- Includes agency name, description, canonical URL, temporal coverage (2020–2024), spatial coverage, publisher, and data source attribution
- Reuses existing in-scope variables (`metaDescription`, `canonicalAgencyUrl`, `jurisdictionDisplay`, etc.) — no new data fetching
- Complements the existing `WebSite` JSON-LD on the homepage

