### PR TITLE
Fix JSON-LD schema rendered as literal text

### DIFF
--- a/packages/web/src/routes/+page.svelte
+++ b/packages/web/src/routes/+page.svelte
@@ -238,9 +238,7 @@
     property="twitter:description"
     content="Who gets stopped? why? What happens next? This tool reveals how traffic enforcement varies across Missouri's agencies."
   />
-  <script type="application/ld+json">
-    {JSON.stringify(webSiteSchema)}
-  </script>
+  {@html `<script type="application/ld+json">${JSON.stringify(webSiteSchema)}</script>`}
 </svelte:head>
 
 <StickyHeader agencies={data.agencies} />


### PR DESCRIPTION
## Summary

Svelte doesn't evaluate `{expressions}` inside `<script>` tags in templates — they're output as literal text. So Google (and any HTML parser) was seeing the raw string `{JSON.stringify(webSiteSchema)}` instead of the actual schema JSON.

Fix: use `{@html}` to inject the entire script tag so the expression is evaluated.

closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)