### PR TITLE
Restore wildcard import in MetricChartModal

### DIFF
--- a/packages/web/src/lib/components/MetricChartModal.svelte
+++ b/packages/web/src/lib/components/MetricChartModal.svelte
@@ -22,6 +22,7 @@
     race_total,
     race_white,
   } from "$lib/paraglide/messages";
+  import * as m from "$lib/paraglide/messages";
   import { raceColors as importedRaceColors } from "$lib/colors.js";
 
   export let open = false;


### PR DESCRIPTION
Fixes regression introduced in #157. `MetricChartModal` uses a dynamic `m[key]` lookup (same pattern as `+layout.svelte`) which requires the wildcard import — removing it broke the agency metrics table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)