### PR TITLE
Restore wildcard import in HomeAgencyMetricTable

### DIFF
--- a/packages/web/src/lib/components/HomeAgencyMetricTable.svelte
+++ b/packages/web/src/lib/components/HomeAgencyMetricTable.svelte
@@ -18,6 +18,7 @@
     home_metric_col_agency,
     home_metric_col_total_stops,
   } from "$lib/paraglide/messages.js";
+  import * as m from "$lib/paraglide/messages.js";
   import GridAgencyLinkCell from "$lib/components/grid/GridAgencyLinkCell.svelte";
 
   type AgencyIndexEntry = {


### PR DESCRIPTION
Fixes prod regression introduced in #157. `HomeAgencyMetricTable` has a dynamic `m[key]` lookup (line 149) for metric labels that requires the wildcard import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)