### PR TITLE
Fix trailing slash 308 redirect hurting Google indexing

### DIFF
--- a/packages/web/src/routes/+layout.ts
+++ b/packages/web/src/routes/+layout.ts
@@ -1,3 +1,5 @@
+export const trailingSlash = "ignore";
+
 import { env } from "$env/dynamic/public";
 import { withDataBase } from "$lib/dataBase";
 


### PR DESCRIPTION
## Summary

SvelteKit's default trailing slash handling was returning `308` for URLs like `/en/`, which Google flags as redirect errors in Search Console.

Setting `trailingSlash = "ignore"` in the root layout makes `/en` and `/en/` both serve content without redirecting.

closes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)