### PR TITLE
Document census_geoid field in agency_index downloads

### DIFF
--- a/packages/web/content/about-the-data.en.md
+++ b/packages/web/content/about-the-data.en.md
@@ -786,6 +786,7 @@ The agency index is an aggregation of agency metadata and the VSR names. Notable
 - `agency_slug` — slugified canonical name (apostrophes removed, punctuation collapsed)
 - `names` — **array of known names** for the agency (canonical, crosswalked, and VSR variants)
 - `city`, `zip`, `phone`, `county` — from the agency reference database
+- `census_geoid` — US Census GEOID for the agency's jurisdiction
 - `rates-by-race--totals--all-stops` and `all_stops_total` — the most recent total stops, for weighting/search
 
 **CSV quirk:** `names` is serialized as a JSON array string in CSV (e.g. `"[\"Agency A\", \"Agency A PD\"]"`).

--- a/packages/web/content/about-the-data.es.md
+++ b/packages/web/content/about-the-data.es.md
@@ -788,6 +788,7 @@ El índice de agencias es una agregación de metadatos de agencias y los nombres
 - `agency_slug` — nombre canónico en formato slug (apóstrofes eliminados, puntuación colapsada)
 - `names` — **arreglo de nombres conocidos** para la agencia (canónico, puente de conexión y variantes del VSR)
 - `city`, `zip`, `phone`, `county` — de la base de datos de referencia de agencias
+- `census_geoid` — identificador geográfico del Censo de EE. UU. (GEOID) para la jurisdicción de la agencia
 - `rates-by-race--totals--all-stops` y `all_stops_total` — las paradas totales más recientes, para ponderación/búsqueda
 
 **Peculiaridad del CSV:** `names` se serializa como una cadena de arreglo JSON en CSV (p. ej., `"[\"Agency A\", \"Agency A PD\"]"`).


### PR DESCRIPTION
## Summary

- Adds `census_geoid` (US Census GEOID for the agency's jurisdiction) to the notable fields list in the Agency index section of both `about-the-data.en.md` and `about-the-data.es.md`

closes #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)