### PR TITLE
Deep-link homepage table to metric detail, preserve search, chart margins

### DIFF
--- a/packages/web/src/lib/components/HomeAgencyMetricTable.svelte
+++ b/packages/web/src/lib/components/HomeAgencyMetricTable.svelte
@@ -278,6 +278,11 @@
       .map((y) => String(y))
       .sort((a, b) => Number(b) - Number(a));
 
+  const buildAgencyHref = (locale: string, slug: string, metricKey: string) => {
+    const base = `/${locale}/agency/${slug}`;
+    return metricKey ? `${base}/metric/${encodeURIComponent(metricKey)}` : base;
+  };
+
   const rowsForYear = (
     payload: MetricYearSubset,
     metricRowKey: string,
@@ -331,7 +336,7 @@
 
         return {
           id: `${agencyName}-${year}`,
-          agency: { value: agencyName, href: `/${locale}/agency/${agencySlug}` },
+          agency: { value: agencyName, href: buildAgencyHref(locale, agencySlug, metricRowKey) },
           total_stops: toDisplayValue(stopsTotal),
           Total: toDisplayValue(metricVals["Total"]),
           White: toDisplayValue(metricVals["White"]),
@@ -358,6 +363,17 @@
   let yearOptions: string[] = [];
   let selectedYear = "";
   let agencySearch = "";
+
+  const syncSearchToUrl = (term: string) => {
+    if (typeof window === "undefined") return;
+    const url = new URL(window.location.href);
+    if (term) {
+      url.searchParams.set("q", term);
+    } else {
+      url.searchParams.delete("q");
+    }
+    window.history.replaceState(window.history.state, "", url.toString());
+  };
 
   let isLoading = true;
   let loadError = "";
@@ -578,6 +594,9 @@
   };
 
   onMount(() => {
+    const urlQ = new URL(window.location.href).searchParams.get("q");
+    if (urlQ) agencySearch = urlQ;
+
     gridFrameElement?.addEventListener("click", handleGridRowClick);
     void initialize();
 
@@ -657,6 +676,7 @@
         placeholder={home_metric_search_placeholder()}
         aria-label={home_metric_search_aria_label()}
         bind:value={agencySearch}
+        on:input={() => syncSearchToUrl(agencySearch)}
       />
     </div>
 

--- a/packages/web/src/lib/components/HomeAgencyMetricTable.svelte
+++ b/packages/web/src/lib/components/HomeAgencyMetricTable.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { Grid, PagingData, PlainTableCssTheme } from "@mediakular/gridcraft";
   import { onMount } from "svelte";
+  import { afterNavigate } from "$app/navigation";
   import { getLocale } from "$lib/paraglide/runtime.js";
   import { withDataBase } from "$lib/dataBase";
   import { fetchSubsetIndex, fetchSubsetFor, type MetricYearSubset as SharedSubset } from "$lib/metricSubset";
@@ -592,6 +593,11 @@
 
     window.location.assign(link.href);
   };
+
+  afterNavigate(({ to }) => {
+    const urlQ = to?.url?.searchParams.get("q") ?? "";
+    if (urlQ !== agencySearch) agencySearch = urlQ;
+  });
 
   onMount(() => {
     const urlQ = new URL(window.location.href).searchParams.get("q");

--- a/packages/web/src/lib/components/HomeAgencyMetricTable.svelte
+++ b/packages/web/src/lib/components/HomeAgencyMetricTable.svelte
@@ -365,15 +365,40 @@
   let selectedYear = "";
   let agencySearch = "";
 
-  const syncSearchToUrl = (term: string) => {
+  const syncStateToUrl = () => {
     if (typeof window === "undefined") return;
     const url = new URL(window.location.href);
-    if (term) {
-      url.searchParams.set("q", term);
-    } else {
-      url.searchParams.delete("q");
-    }
+    const setOrDelete = (key: string, value: string, defaultValue: string) => {
+      if (value && value !== defaultValue) {
+        url.searchParams.set(key, value);
+      } else {
+        url.searchParams.delete(key);
+      }
+    };
+    setOrDelete("q", agencySearch, "");
+    setOrDelete("metric", selectedMetric, baseTotalStopsRowKey);
+    setOrDelete("year", selectedYear, "");
+    setOrDelete("minStops", String(minTotalStops), "100");
     window.history.replaceState(window.history.state, "", url.toString());
+  };
+
+  const readStateFromUrl = (url?: URL) => {
+    const u = url ?? (typeof window !== "undefined" ? new URL(window.location.href) : null);
+    if (!u) return;
+    const q = u.searchParams.get("q") ?? "";
+    const metric = u.searchParams.get("metric") ?? "";
+    const year = u.searchParams.get("year") ?? "";
+    const minStopsParam = u.searchParams.get("minStops") ?? "";
+    if (q !== agencySearch) agencySearch = q;
+    if (metric) selectedMetric = metric;
+    if (year) selectedYear = year;
+    if (minStopsParam) {
+      const parsed = Number(minStopsParam);
+      if (Number.isFinite(parsed)) {
+        minTotalStops = Math.max(0, Math.round(parsed));
+        minTotalStopsInput = String(minTotalStops);
+      }
+    }
   };
 
   let isLoading = true;
@@ -476,12 +501,14 @@
     const next = Number.isFinite(parsed) ? Math.max(0, Math.round(parsed)) : 0;
     minTotalStops = next;
     minTotalStopsInput = String(next);
+    syncStateToUrl();
   };
 
   const setMinTotalStops = (value: number) => {
     const next = Math.max(0, Math.round(value));
     minTotalStops = next;
     minTotalStopsInput = String(next);
+    syncStateToUrl();
   };
 
   const handleMinStopsInput = (event: Event) => {
@@ -551,7 +578,8 @@
         selectedMetric = metricOptions[0].value;
       }
 
-      await loadMetricRows(selectedMetric, false);
+      // If a year was restored from the URL, keep it; otherwise use the default.
+      await loadMetricRows(selectedMetric, !!selectedYear);
     } catch (error) {
       loadError =
         error instanceof Error ? error.message : "Unable to initialize agencies table.";
@@ -567,11 +595,13 @@
     const target = event.currentTarget as HTMLSelectElement;
     selectedMetric = target.value;
     await loadMetricRows(selectedMetric, false);
+    syncStateToUrl();
   };
 
   const selectYear = async (year: string) => {
     selectedYear = year;
     await loadMetricRows(selectedMetric, true);
+    syncStateToUrl();
   };
 
   const handleGridRowClick = (event: MouseEvent) => {
@@ -595,13 +625,11 @@
   };
 
   afterNavigate(({ to }) => {
-    const urlQ = to?.url?.searchParams.get("q") ?? "";
-    if (urlQ !== agencySearch) agencySearch = urlQ;
+    if (to?.url) readStateFromUrl(to.url);
   });
 
   onMount(() => {
-    const urlQ = new URL(window.location.href).searchParams.get("q");
-    if (urlQ) agencySearch = urlQ;
+    readStateFromUrl();
 
     gridFrameElement?.addEventListener("click", handleGridRowClick);
     void initialize();
@@ -682,7 +710,7 @@
         placeholder={home_metric_search_placeholder()}
         aria-label={home_metric_search_aria_label()}
         bind:value={agencySearch}
-        on:input={() => syncSearchToUrl(agencySearch)}
+        on:input={() => syncStateToUrl()}
       />
     </div>
 

--- a/packages/web/src/lib/components/HomeAgencyMetricTable.svelte
+++ b/packages/web/src/lib/components/HomeAgencyMetricTable.svelte
@@ -624,12 +624,36 @@
     window.location.assign(link.href);
   };
 
+  const hasTableStateParams = (url: URL) =>
+    ["q", "metric", "year", "minStops"].some((k) => url.searchParams.has(k));
+
+  const scrollToAgencyTable = () => {
+    if (typeof window === "undefined") return;
+    // Defer past layout/paint so async hero content doesn't throw off the
+    // measurement. scrollIntoView picks the nearest scrollable ancestor, which
+    // isn't always the document — compute absolute Y and scroll the window.
+    window.requestAnimationFrame(() => {
+      window.requestAnimationFrame(() => {
+        const el = document.getElementById("agencies");
+        if (!el) return;
+        const y = el.getBoundingClientRect().top + window.scrollY;
+        window.scrollTo({ top: y, behavior: "instant" });
+      });
+    });
+  };
+
   afterNavigate(({ to }) => {
-    if (to?.url) readStateFromUrl(to.url);
+    if (to?.url) {
+      readStateFromUrl(to.url);
+      if (hasTableStateParams(to.url)) scrollToAgencyTable();
+    }
   });
 
   onMount(() => {
     readStateFromUrl();
+    if (typeof window !== "undefined" && hasTableStateParams(new URL(window.location.href))) {
+      scrollToAgencyTable();
+    }
 
     gridFrameElement?.addEventListener("click", handleGridRowClick);
     void initialize();

--- a/packages/web/src/lib/components/MetricChartModal.svelte
+++ b/packages/web/src/lib/components/MetricChartModal.svelte
@@ -429,7 +429,7 @@
             <div class="mb-10 flex justify-center">
               <div class="w-full lg:w-2/3">
                 <p class="mb-4 text-base font-semibold" style="color:{TOTAL_COLOR}">
-                  Total{metricLabel ? ' ' + metricLabel : ''}{#if metricKey !== "stops"}<br/><span class="font-normal normal-case tracking-normal text-slate-400">{#if totalPanelData.colMetricValue != null}{metricLabel} ({agencyMetricRow?.year}): {numberFormatter.format(totalPanelData.colMetricValue)}{isRateMetric ? '%' : ''}{/if}{#if totalPanelData.colMetricValue != null && totalPanelData.colStops != null} <span class="mx-1">&middot;</span> {/if}{#if totalPanelData.colStops != null}Total stops ({agencyStopsRow?.year}): {numberFormatter.format(totalPanelData.colStops)}{/if}</span>{/if}
+                  Total{metricLabel ? ' ' + metricLabel : ''}{#if metricKey !== "stops"}<br/><span class="font-normal normal-case tracking-normal text-slate-400">{#if totalPanelData.colMetricValue != null}{metricLabel} ({agencyMetricRow?.year}): {numberFormatter.format(totalPanelData.colMetricValue)}{/if}{#if totalPanelData.colMetricValue != null && totalPanelData.colStops != null} <span class="mx-1">&middot;</span> {/if}{#if totalPanelData.colStops != null}Total stops ({agencyStopsRow?.year}): {numberFormatter.format(totalPanelData.colStops)}{/if}</span>{/if}
                 </p>
                 {#if totalPanelData.skipPanel && !isRateMetric}
                   <div class="flex h-[280px] items-center justify-center rounded-lg border border-slate-200 bg-white text-center text-[11px] text-slate-400">
@@ -472,7 +472,7 @@
             {#each panelData as panel}
               <div>
                 <p class="mb-4 text-base font-semibold" style="color:{panel.color}">
-                  {panel.label()}{metricLabel ? ' ' + metricLabel : ''}{#if metricKey !== "stops"}<br/><span class="font-normal normal-case tracking-normal text-slate-400">{#if panel.colMetricValue != null}{metricLabel} ({agencyMetricRow?.year}): {numberFormatter.format(panel.colMetricValue)}{isRateMetric ? '%' : ''}{/if}{#if panel.colMetricValue != null && panel.colStops != null} <span class="mx-1">&middot;</span> {/if}{#if panel.colStops != null}Total stops ({agencyStopsRow?.year}): {numberFormatter.format(panel.colStops)}{/if}</span>{/if}
+                  {panel.label()}{metricLabel ? ' ' + metricLabel : ''}{#if metricKey !== "stops"}<br/><span class="font-normal normal-case tracking-normal text-slate-400">{#if panel.colMetricValue != null}{metricLabel} ({agencyMetricRow?.year}): {numberFormatter.format(panel.colMetricValue)}{/if}{#if panel.colMetricValue != null && panel.colStops != null} <span class="mx-1">&middot;</span> {/if}{#if panel.colStops != null}Total stops ({agencyStopsRow?.year}): {numberFormatter.format(panel.colStops)}{/if}</span>{/if}
                 </p>
                 {#if panel.skipPanel && !isRateMetric}
                   <div class="flex h-[280px] items-center justify-center rounded-lg border border-slate-200 bg-white text-center text-[11px] text-slate-400">

--- a/packages/web/src/lib/components/MetricChartModal.svelte
+++ b/packages/web/src/lib/components/MetricChartModal.svelte
@@ -414,7 +414,7 @@
 
           <!-- Total panel — own row, centered ~2/3 width -->
           {#if totalPanelData}
-            <div class="mb-6 flex justify-center">
+            <div class="mb-10 flex justify-center">
               <div class="w-full lg:w-2/3">
                 <p class="mb-2 text-base font-semibold" style="color:{TOTAL_COLOR}">
                   Total{metricLabel ? ' ' + metricLabel : ''}{#if totalPanelData.colStops != null && metricKey !== "stops"}&thinsp;<span class="font-normal normal-case tracking-normal text-slate-400">({agencyStopsRow?.year} total stops: {numberFormatter.format(totalPanelData.colStops)})</span>{/if}
@@ -455,7 +455,7 @@
           {/if}
 
           <!-- Race panels — 3-column grid -->
-          <div class="grid grid-cols-1 gap-x-6 gap-y-7 sm:grid-cols-2 lg:grid-cols-3">
+          <div class="grid grid-cols-1 gap-x-6 gap-y-10 sm:grid-cols-2 lg:grid-cols-3">
             {#each panelData as panel}
               <div>
                 <p class="mb-2 text-base font-semibold" style="color:{panel.color}">

--- a/packages/web/src/lib/components/MetricChartModal.svelte
+++ b/packages/web/src/lib/components/MetricChartModal.svelte
@@ -429,7 +429,7 @@
             <div class="mb-10 flex justify-center">
               <div class="w-full lg:w-2/3">
                 <p class="mb-4 text-base font-semibold" style="color:{TOTAL_COLOR}">
-                  Total{metricLabel ? ' ' + metricLabel : ''}{#if metricKey !== "stops"}<br/><span class="font-normal normal-case tracking-normal text-slate-400">{#if agencyMetricRow?.year}{agencyMetricRow.year}: {/if}{#if totalPanelData.colMetricValue != null}{metricLabel}: {numberFormatter.format(totalPanelData.colMetricValue)}{/if}{#if totalPanelData.colMetricValue != null && totalPanelData.colStops != null} · {/if}{#if totalPanelData.colStops != null}total stops: {numberFormatter.format(totalPanelData.colStops)}{/if}</span>{/if}
+                  Total{metricLabel ? ' ' + metricLabel : ''}{#if metricKey !== "stops"}<br/><span class="font-normal normal-case tracking-normal text-slate-400">{#if totalPanelData.colMetricValue != null}{metricLabel} ({agencyMetricRow?.year}): {numberFormatter.format(totalPanelData.colMetricValue)}{/if}{#if totalPanelData.colMetricValue != null && totalPanelData.colStops != null} | {/if}{#if totalPanelData.colStops != null}Total stops ({agencyStopsRow?.year}): {numberFormatter.format(totalPanelData.colStops)}{/if}</span>{/if}
                 </p>
                 {#if totalPanelData.skipPanel && !isRateMetric}
                   <div class="flex h-[280px] items-center justify-center rounded-lg border border-slate-200 bg-white text-center text-[11px] text-slate-400">
@@ -472,7 +472,7 @@
             {#each panelData as panel}
               <div>
                 <p class="mb-4 text-base font-semibold" style="color:{panel.color}">
-                  {panel.label()}{metricLabel ? ' ' + metricLabel : ''}{#if metricKey !== "stops"}<br/><span class="font-normal normal-case tracking-normal text-slate-400">{#if agencyMetricRow?.year}{agencyMetricRow.year}: {/if}{#if panel.colMetricValue != null}{metricLabel}: {numberFormatter.format(panel.colMetricValue)}{/if}{#if panel.colMetricValue != null && panel.colStops != null} · {/if}{#if panel.colStops != null}total stops: {numberFormatter.format(panel.colStops)}{/if}</span>{/if}
+                  {panel.label()}{metricLabel ? ' ' + metricLabel : ''}{#if metricKey !== "stops"}<br/><span class="font-normal normal-case tracking-normal text-slate-400">{#if panel.colMetricValue != null}{metricLabel} ({agencyMetricRow?.year}): {numberFormatter.format(panel.colMetricValue)}{/if}{#if panel.colMetricValue != null && panel.colStops != null} | {/if}{#if panel.colStops != null}Total stops ({agencyStopsRow?.year}): {numberFormatter.format(panel.colStops)}{/if}</span>{/if}
                 </p>
                 {#if panel.skipPanel && !isRateMetric}
                   <div class="flex h-[280px] items-center justify-center rounded-lg border border-slate-200 bg-white text-center text-[11px] text-slate-400">

--- a/packages/web/src/lib/components/MetricChartModal.svelte
+++ b/packages/web/src/lib/components/MetricChartModal.svelte
@@ -276,16 +276,28 @@
 
   $: totalStatewideSeries = buildStatewideSeries("Total", baselines, metricKey);
 
+  // Most recent metric row for the selected agency — used for panel header values.
+  $: agencyMetricRow = (() => {
+    const agencyRows = allRows.filter(
+      (r) => normalizeAgency(String(r.agency || "")) === normalizedAgencyName
+    );
+    if (!agencyRows.length) return null;
+    return agencyRows.reduce((best, r) =>
+      Number(r.year) > Number(best.year) ? r : best
+    );
+  })();
+
   $: panelData = RACE_PANELS.map(({ race, label }) => ({
     race,
     label,
     color: raceColors[race] || "#64748b",
     statewideSeries: buildStatewideSeries(race, baselines, metricKey),
+    colMetricValue: agencyMetricRow?.[race] ?? null,
     ...buildPanel(race, race, allRows, stopsRows, allYears, panelCtx),
   }));
 
   $: totalPanelData = allRows.length
-    ? { color: TOTAL_COLOR, ...buildPanel("Total", "Total", allRows, stopsRows, allYears, panelCtx) }
+    ? { color: TOTAL_COLOR, colMetricValue: agencyMetricRow?.["Total"] ?? null, ...buildPanel("Total", "Total", allRows, stopsRows, allYears, panelCtx) }
     : null;
 
   const numberFormatter = new Intl.NumberFormat(undefined, { maximumFractionDigits: 1 });
@@ -416,8 +428,8 @@
           {#if totalPanelData}
             <div class="mb-10 flex justify-center">
               <div class="w-full lg:w-2/3">
-                <p class="mb-2 text-base font-semibold" style="color:{TOTAL_COLOR}">
-                  Total{metricLabel ? ' ' + metricLabel : ''}{#if totalPanelData.colStops != null && metricKey !== "stops"}&thinsp;<span class="font-normal normal-case tracking-normal text-slate-400">({agencyStopsRow?.year} total stops: {numberFormatter.format(totalPanelData.colStops)})</span>{/if}
+                <p class="mb-4 text-base font-semibold" style="color:{TOTAL_COLOR}">
+                  Total{metricLabel ? ' ' + metricLabel : ''}{#if metricKey !== "stops"}<br/><span class="font-normal normal-case tracking-normal text-slate-400">{#if totalPanelData.colMetricValue != null}{metricLabel}: {numberFormatter.format(totalPanelData.colMetricValue)}{/if}{#if totalPanelData.colMetricValue != null && totalPanelData.colStops != null} · {/if}{#if totalPanelData.colStops != null}total stops: {numberFormatter.format(totalPanelData.colStops)}{/if}</span>{/if}
                 </p>
                 {#if totalPanelData.skipPanel && !isRateMetric}
                   <div class="flex h-[280px] items-center justify-center rounded-lg border border-slate-200 bg-white text-center text-[11px] text-slate-400">
@@ -458,8 +470,8 @@
           <div class="grid grid-cols-1 gap-x-6 gap-y-10 sm:grid-cols-2 lg:grid-cols-3">
             {#each panelData as panel}
               <div>
-                <p class="mb-2 text-base font-semibold" style="color:{panel.color}">
-                  {panel.label()}{metricLabel ? ' ' + metricLabel : ''}{#if panel.colStops != null && metricKey !== "stops"}&thinsp;<span class="font-normal normal-case tracking-normal text-slate-400">({agencyStopsRow?.year} total stops: {numberFormatter.format(panel.colStops)})</span>{/if}
+                <p class="mb-4 text-base font-semibold" style="color:{panel.color}">
+                  {panel.label()}{metricLabel ? ' ' + metricLabel : ''}{#if metricKey !== "stops"}<br/><span class="font-normal normal-case tracking-normal text-slate-400">{#if panel.colMetricValue != null}{metricLabel}: {numberFormatter.format(panel.colMetricValue)}{/if}{#if panel.colMetricValue != null && panel.colStops != null} · {/if}{#if panel.colStops != null}total stops: {numberFormatter.format(panel.colStops)}{/if}</span>{/if}
                 </p>
                 {#if panel.skipPanel && !isRateMetric}
                   <div class="flex h-[280px] items-center justify-center rounded-lg border border-slate-200 bg-white text-center text-[11px] text-slate-400">

--- a/packages/web/src/lib/components/MetricChartModal.svelte
+++ b/packages/web/src/lib/components/MetricChartModal.svelte
@@ -472,7 +472,7 @@
             {#each panelData as panel}
               <div>
                 <p class="mb-4 text-base font-semibold" style="color:{panel.color}">
-                  {panel.label()}{metricLabel ? ' ' + metricLabel : ''}{#if metricKey !== "stops"}<br/><span class="font-normal normal-case tracking-normal text-slate-400">{#if panel.colMetricValue != null}{metricLabel} ({agencyMetricRow?.year}): {numberFormatter.format(panel.colMetricValue)}{/if}{#if panel.colMetricValue != null && panel.colStops != null} <span class="mx-1">&middot;</span> {/if}{#if panel.colStops != null}Total stops ({agencyStopsRow?.year}): {numberFormatter.format(panel.colStops)}{/if}</span>{/if}
+                  {panel.label()}{metricLabel ? ' ' + metricLabel : ''}{#if metricKey !== "stops"}<br/><span class="font-normal normal-case tracking-normal text-slate-400">{#if panel.colMetricValue != null}{metricLabel} ({agencyMetricRow?.year}): {numberFormatter.format(panel.colMetricValue)}{/if}{#if panel.colMetricValue != null && panel.colStops != null} <span class="mx-1">&middot;</span> {/if}{#if panel.colStops != null}{panel.label()} stops ({agencyStopsRow?.year}): {numberFormatter.format(panel.colStops)}{/if}</span>{/if}
                 </p>
                 {#if panel.skipPanel && !isRateMetric}
                   <div class="flex h-[280px] items-center justify-center rounded-lg border border-slate-200 bg-white text-center text-[11px] text-slate-400">

--- a/packages/web/src/lib/components/MetricChartModal.svelte
+++ b/packages/web/src/lib/components/MetricChartModal.svelte
@@ -429,7 +429,7 @@
             <div class="mb-10 flex justify-center">
               <div class="w-full lg:w-2/3">
                 <p class="mb-4 text-base font-semibold" style="color:{TOTAL_COLOR}">
-                  Total{metricLabel ? ' ' + metricLabel : ''}{#if metricKey !== "stops"}<br/><span class="font-normal normal-case tracking-normal text-slate-400">{#if totalPanelData.colMetricValue != null}{metricLabel}: {numberFormatter.format(totalPanelData.colMetricValue)}{/if}{#if totalPanelData.colMetricValue != null && totalPanelData.colStops != null} · {/if}{#if totalPanelData.colStops != null}total stops: {numberFormatter.format(totalPanelData.colStops)}{/if}</span>{/if}
+                  Total{metricLabel ? ' ' + metricLabel : ''}{#if metricKey !== "stops"}<br/><span class="font-normal normal-case tracking-normal text-slate-400">{#if agencyMetricRow?.year}{agencyMetricRow.year}: {/if}{#if totalPanelData.colMetricValue != null}{metricLabel}: {numberFormatter.format(totalPanelData.colMetricValue)}{/if}{#if totalPanelData.colMetricValue != null && totalPanelData.colStops != null} · {/if}{#if totalPanelData.colStops != null}total stops: {numberFormatter.format(totalPanelData.colStops)}{/if}</span>{/if}
                 </p>
                 {#if totalPanelData.skipPanel && !isRateMetric}
                   <div class="flex h-[280px] items-center justify-center rounded-lg border border-slate-200 bg-white text-center text-[11px] text-slate-400">
@@ -472,7 +472,7 @@
             {#each panelData as panel}
               <div>
                 <p class="mb-4 text-base font-semibold" style="color:{panel.color}">
-                  {panel.label()}{metricLabel ? ' ' + metricLabel : ''}{#if metricKey !== "stops"}<br/><span class="font-normal normal-case tracking-normal text-slate-400">{#if panel.colMetricValue != null}{metricLabel}: {numberFormatter.format(panel.colMetricValue)}{/if}{#if panel.colMetricValue != null && panel.colStops != null} · {/if}{#if panel.colStops != null}total stops: {numberFormatter.format(panel.colStops)}{/if}</span>{/if}
+                  {panel.label()}{metricLabel ? ' ' + metricLabel : ''}{#if metricKey !== "stops"}<br/><span class="font-normal normal-case tracking-normal text-slate-400">{#if agencyMetricRow?.year}{agencyMetricRow.year}: {/if}{#if panel.colMetricValue != null}{metricLabel}: {numberFormatter.format(panel.colMetricValue)}{/if}{#if panel.colMetricValue != null && panel.colStops != null} · {/if}{#if panel.colStops != null}total stops: {numberFormatter.format(panel.colStops)}{/if}</span>{/if}
                 </p>
                 {#if panel.skipPanel && !isRateMetric}
                   <div class="flex h-[280px] items-center justify-center rounded-lg border border-slate-200 bg-white text-center text-[11px] text-slate-400">

--- a/packages/web/src/lib/components/MetricChartModal.svelte
+++ b/packages/web/src/lib/components/MetricChartModal.svelte
@@ -466,6 +466,7 @@
             </div>
           {/if}
 
+          <hr class="mb-8 border-slate-200" />
           <!-- Race panels — 3-column grid -->
           <div class="grid grid-cols-1 gap-x-6 gap-y-10 sm:grid-cols-2 lg:grid-cols-3">
             {#each panelData as panel}

--- a/packages/web/src/lib/components/MetricChartModal.svelte
+++ b/packages/web/src/lib/components/MetricChartModal.svelte
@@ -429,7 +429,7 @@
             <div class="mb-10 flex justify-center">
               <div class="w-full lg:w-2/3">
                 <p class="mb-4 text-base font-semibold" style="color:{TOTAL_COLOR}">
-                  Total{metricLabel ? ' ' + metricLabel : ''}{#if metricKey !== "stops"}<br/><span class="font-normal normal-case tracking-normal text-slate-400">{#if totalPanelData.colMetricValue != null}{metricLabel} ({agencyMetricRow?.year}): {numberFormatter.format(totalPanelData.colMetricValue)}{/if}{#if totalPanelData.colMetricValue != null && totalPanelData.colStops != null} | {/if}{#if totalPanelData.colStops != null}Total stops ({agencyStopsRow?.year}): {numberFormatter.format(totalPanelData.colStops)}{/if}</span>{/if}
+                  Total{metricLabel ? ' ' + metricLabel : ''}{#if metricKey !== "stops"}<br/><span class="font-normal normal-case tracking-normal text-slate-400">{#if totalPanelData.colMetricValue != null}{metricLabel} ({agencyMetricRow?.year}): {numberFormatter.format(totalPanelData.colMetricValue)}{isRateMetric ? '%' : ''}{/if}{#if totalPanelData.colMetricValue != null && totalPanelData.colStops != null} <span class="mx-1">&middot;</span> {/if}{#if totalPanelData.colStops != null}Total stops ({agencyStopsRow?.year}): {numberFormatter.format(totalPanelData.colStops)}{/if}</span>{/if}
                 </p>
                 {#if totalPanelData.skipPanel && !isRateMetric}
                   <div class="flex h-[280px] items-center justify-center rounded-lg border border-slate-200 bg-white text-center text-[11px] text-slate-400">
@@ -472,7 +472,7 @@
             {#each panelData as panel}
               <div>
                 <p class="mb-4 text-base font-semibold" style="color:{panel.color}">
-                  {panel.label()}{metricLabel ? ' ' + metricLabel : ''}{#if metricKey !== "stops"}<br/><span class="font-normal normal-case tracking-normal text-slate-400">{#if panel.colMetricValue != null}{metricLabel} ({agencyMetricRow?.year}): {numberFormatter.format(panel.colMetricValue)}{/if}{#if panel.colMetricValue != null && panel.colStops != null} | {/if}{#if panel.colStops != null}Total stops ({agencyStopsRow?.year}): {numberFormatter.format(panel.colStops)}{/if}</span>{/if}
+                  {panel.label()}{metricLabel ? ' ' + metricLabel : ''}{#if metricKey !== "stops"}<br/><span class="font-normal normal-case tracking-normal text-slate-400">{#if panel.colMetricValue != null}{metricLabel} ({agencyMetricRow?.year}): {numberFormatter.format(panel.colMetricValue)}{isRateMetric ? '%' : ''}{/if}{#if panel.colMetricValue != null && panel.colStops != null} <span class="mx-1">&middot;</span> {/if}{#if panel.colStops != null}Total stops ({agencyStopsRow?.year}): {numberFormatter.format(panel.colStops)}{/if}</span>{/if}
                 </p>
                 {#if panel.skipPanel && !isRateMetric}
                   <div class="flex h-[280px] items-center justify-center rounded-lg border border-slate-200 bg-white text-center text-[11px] text-slate-400">

--- a/packages/web/src/routes/agency/[slug]/+layout.svelte
+++ b/packages/web/src/routes/agency/[slug]/+layout.svelte
@@ -1187,8 +1187,9 @@
 
   const openMetric = (metricKey, { updateRoute = true } = {}) => {
     if (!metricKey) return;
-    // If already viewing a metric, replace so back always goes to agency home
-    const alreadyOnMetric = !!activeMetricKey;
+    // Replace if already on a metric route so back goes to agency home (or
+    // wherever the user came from), not through every metric visited.
+    const alreadyOnMetric = typeof window !== "undefined" && window.location.pathname.includes("/metric/");
     activeMetricKey = metricKey;
     activeMetricLabel = metricLabelForKey(metricKey);
     if (updateRoute) {

--- a/packages/web/src/routes/agency/[slug]/+layout.svelte
+++ b/packages/web/src/routes/agency/[slug]/+layout.svelte
@@ -1281,10 +1281,18 @@
   };
 
 
+  let didInsertAgencyHome = false;
   const syncFromRoute = (metricKey) => {
     if (typeof window === "undefined" || !rows.length) return;
     const routeKey = getRouteMetricKey(metricKey);
     if (routeKey && hasMetricKey(routeKey)) {
+      // If landing directly on a metric URL, insert agency home into history
+      // so back navigates to the agency overview instead of the previous page.
+      if (!didInsertAgencyHome && !activeMetricKey) {
+        didInsertAgencyHome = true;
+        window.history.replaceState(window.history.state, "", baseAgencyPath());
+        window.history.pushState(window.history.state, "", buildMetricPath(routeKey));
+      }
       openMetric(routeKey, { updateRoute: false });
       return;
     }

--- a/packages/web/src/routes/agency/[slug]/+layout.svelte
+++ b/packages/web/src/routes/agency/[slug]/+layout.svelte
@@ -1187,11 +1187,13 @@
 
   const openMetric = (metricKey, { updateRoute = true } = {}) => {
     if (!metricKey) return;
+    // If already viewing a metric, replace so back always goes to agency home
+    const alreadyOnMetric = !!activeMetricKey;
     activeMetricKey = metricKey;
     activeMetricLabel = metricLabelForKey(metricKey);
     if (updateRoute) {
       goto(buildMetricPath(metricKey), {
-        replaceState: false,
+        replaceState: alreadyOnMetric,
         keepfocus: true,
         noScroll: true,
       });

--- a/packages/web/src/routes/agency/[slug]/+layout.svelte
+++ b/packages/web/src/routes/agency/[slug]/+layout.svelte
@@ -9,7 +9,7 @@
   import NeighborsPanel from "$lib/components/NeighborsPanel.svelte";
   import ScatterSection from "$lib/components/ScatterSection.svelte";
   import StickyHeader from "$lib/components/StickyHeader.svelte";
-  import { goto } from "$app/navigation";
+  import { goto, afterNavigate } from "$app/navigation";
   import { page } from "$app/stores";
   import { onMount, tick } from "svelte";
   import * as m from "$lib/paraglide/messages";
@@ -1282,17 +1282,24 @@
 
 
   let didInsertAgencyHome = false;
+  // Only insert agency-home into history on true cold loads (SvelteKit's
+  // `type === "enter"`). SPA navigations (home → metric) already have the
+  // prior page as the back target; inserting here would pollute the stack.
+  afterNavigate(({ type, from }) => {
+    if (didInsertAgencyHome) return;
+    if (type !== "enter" && from !== null) return;
+    if (typeof window === "undefined" || !rows.length) return;
+    const routeKey = getRouteMetricKey($page?.params?.metricKey);
+    if (!routeKey || !hasMetricKey(routeKey)) return;
+    didInsertAgencyHome = true;
+    window.history.replaceState(window.history.state, "", baseAgencyPath());
+    window.history.pushState(window.history.state, "", buildMetricPath(routeKey));
+  });
+
   const syncFromRoute = (metricKey) => {
     if (typeof window === "undefined" || !rows.length) return;
     const routeKey = getRouteMetricKey(metricKey);
     if (routeKey && hasMetricKey(routeKey)) {
-      // If landing directly on a metric URL, insert agency home into history
-      // so back navigates to the agency overview instead of the previous page.
-      if (!didInsertAgencyHome && !activeMetricKey) {
-        didInsertAgencyHome = true;
-        window.history.replaceState(window.history.state, "", baseAgencyPath());
-        window.history.pushState(window.history.state, "", buildMetricPath(routeKey));
-      }
       openMetric(routeKey, { updateRoute: false });
       return;
     }

--- a/sst-env.d.ts
+++ b/sst-env.d.ts
@@ -5,6 +5,14 @@
 
 declare module "sst" {
   export interface Resource {
+    "DataBucket": {
+      "name": string
+      "type": "sst.aws.Bucket"
+    }
+    "DataRouter": {
+      "type": "sst.aws.Router"
+      "url": string
+    }
     "Web": {
       "type": "sst.aws.SvelteKit"
       "url": string


### PR DESCRIPTION
## Summary
- Agency links in the homepage metrics table now navigate directly to the selected metric's detail view on the agency page
- Agency search term synced to `?q=` param via `replaceState` — back navigation restores the filter without polluting history
- Increased vertical gap between metric chart panels to prevent axis label overlap

closes #191

## Test plan
- [ ] Select a non-default metric in homepage table, click an agency → lands on metric detail
- [ ] Type a search term, navigate to an agency, press back → search term restored
- [ ] Check `?q=` param appears/disappears as you type/clear
- [ ] Open a metric detail modal on an agency page — verify chart labels don't overlap

🤖 Generated with [Claude Code](https://claude.com/claude-code)