### PR TITLE
Homepage table: default metric links to agency home

### DIFF
--- a/packages/web/src/lib/components/HomeAgencyMetricTable.svelte
+++ b/packages/web/src/lib/components/HomeAgencyMetricTable.svelte
@@ -357,7 +357,11 @@
           id: `${agencyName}-${year}`,
           agency: {
             value: agencyName,
-            href: buildAgencyHref(locale, agencySlug, metricRowKey),
+            href: buildAgencyHref(
+              locale,
+              agencySlug,
+              metricRowKey === baseTotalStopsRowKey ? "" : metricRowKey,
+            ),
             program287g: program287gSlugs.has(agencySlug),
           },
           total_stops: toDisplayValue(stopsTotal),


### PR DESCRIPTION
## Summary
- Clicking an agency row in the homepage metrics table with the default "Total Stops" metric selected now links to `/agency/{slug}` instead of `/agency/{slug}/metric/stops`.
- Every other metric continues to deep-link into the metric page.

## Test plan
- [ ] Load homepage, default "Total Stops" metric — click any row → lands on the agency overview.
- [ ] Switch metric to e.g. "Search Rate" — click any row → lands on `/agency/{slug}/metric/search-rate`.
- [ ] Verify the "hidden over 100%" excluded-agency footer links also follow the same rule (they share the same href construction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)