### PR TITLE
Statewide aggregate: chart scale fix, stripped page, suppressed spaghetti, search pin

### DIFF
--- a/packages/web/src/lib/components/MetricChartModal.svelte
+++ b/packages/web/src/lib/components/MetricChartModal.svelte
@@ -14,6 +14,7 @@
   } from "$lib/paraglide/messages";
   import * as m from "$lib/paraglide/messages";
   import { raceColors } from "$lib/colors.js";
+  import { STATEWIDE_AGG_NORMALIZED } from "$lib/statewide.js";
   import SpaghettiChart from "$lib/components/SpaghettiChart.svelte";
   import StatewideComparisonChart from "$lib/components/StatewideComparisonChart.svelte";
 
@@ -74,10 +75,9 @@
   // MSHP dominates count scales — excluded from grey series by default.
   const MSHP_NORMALIZED = "missouri state highway patrol";
 
-  // The statewide aggregate row ("Missouri (all agencies)"). Its rate is the
-  // stop-weighted statewide rate (Σnumerator / Σdenominator) — what the grey
-  // "MO" reference line should show.
-  const STATEWIDE_AGG_NORMALIZED = "missouri all agencies";
+  // The statewide aggregate row ("Missouri (all agencies)") — STATEWIDE_AGG_NORMALIZED,
+  // imported from $lib/statewide. Its rate is the stop-weighted statewide rate
+  // (Σnumerator / Σdenominator) — what the grey "MO" reference line should show.
 
   const fetchMetricRows = (key) => {
     if (!key) return Promise.resolve([]);
@@ -139,6 +139,13 @@
     .filter(Number.isFinite)
     .sort((a, b) => a - b);
   $: normalizedAgencyName = normalizeAgency(agencyName);
+  // On the statewide aggregate's own page the selected line IS the statewide
+  // total, so the grey spaghetti / "MO" reference line is redundant noise —
+  // suppress it and draw just the single statewide line.
+  $: isStatewidePage = normalizedAgencyName === STATEWIDE_AGG_NORMALIZED;
+
+  // A blank rate series → StatewideComparisonChart draws no grey "MO" line.
+  const EMPTY_RATE_SERIES = { data: [] };
 
   // Most recent stops row for the selected agency (used for panel skip + header label)
   $: agencyStopsRow = (() => {
@@ -190,7 +197,7 @@
   const buildPanel = (col, stopsCol, allRows, stopsRows, allYears, ctx) => {
     const {
       normalizedAgencyName, isRateMetric, minStopsThreshold, maxStopsThreshold,
-      showMSHP, sharedRateYMax, agencyStopsRow, agencyMaxTotalStops,
+      showMSHP, sharedRateYMax, agencyStopsRow, agencyMaxTotalStops, isStatewidePage,
     } = ctx;
 
     const byAgency = new Map();
@@ -223,10 +230,15 @@
         selectedSeries = { agency, data };
       } else {
         const isMSHP = normAgency === MSHP_NORMALIZED;
+        const isStatewideAgg = normAgency === STATEWIDE_AGG_NORMALIZED;
         const totalStops = agencyMaxTotalStops.get(normAgency) ?? 0;
         const passesMin = totalStops >= minStopsThreshold;
         const passesMax = maxStopsThreshold == null || totalStops <= maxStopsThreshold;
-        if (passesMin && passesMax && (showMSHP || !isMSHP)) {
+        // Never draw the statewide aggregate as a grey count line — its
+        // Σ-all-agencies magnitude dwarfs every real agency and warps the
+        // y-axis. And on the statewide page itself, suppress the grey
+        // spaghetti entirely so only the single statewide line shows.
+        if (!isStatewidePage && !isStatewideAgg && passesMin && passesMax && (showMSHP || !isMSHP)) {
           greySeries.push({ agency, data });
         }
       }
@@ -257,7 +269,7 @@
 
   $: panelCtx = {
     normalizedAgencyName, isRateMetric, minStopsThreshold, maxStopsThreshold,
-    showMSHP, sharedRateYMax, agencyStopsRow, agencyMaxTotalStops,
+    showMSHP, sharedRateYMax, agencyStopsRow, agencyMaxTotalStops, isStatewidePage,
   };
 
   // ── Statewide series (rate metrics) ───────────────────────────────────────
@@ -394,8 +406,9 @@
         {:else if !agencyHasData}
           <p class="text-sm text-slate-500">{modal_no_agency_data()}</p>
         {:else}
-          <!-- Filter / scale controls (count metrics only) -->
-          {#if !isRateMetric}
+          <!-- Filter / scale controls (count metrics only; none apply on the
+               statewide page — one line, no grey series, fixed linear scale) -->
+          {#if !isRateMetric && !isStatewidePage}
             <div class="mb-4 flex flex-wrap items-center justify-end gap-3">
               <!-- MSHP toggle -->
               <button
@@ -465,7 +478,7 @@
                   <div class="h-[280px]">
                     {#if isRateMetric}
                       <StatewideComparisonChart
-                        statewideSeries={totalStatewideSeries}
+                        statewideSeries={isStatewidePage ? EMPTY_RATE_SERIES : totalStatewideSeries}
                         selectedSeries={totalPanelData.selectedSeries}
                         {allYears}
                         yMax={totalPanelData.yMax}
@@ -479,7 +492,7 @@
                         selectedSeries={totalPanelData.selectedSeries}
                         {allYears}
                         yMax={totalPanelData.yMax}
-                        useSqrt={useSqrtScale && !isRateMetric}
+                        useSqrt={useSqrtScale && !isRateMetric && !isStatewidePage}
                         {isRateMetric}
                         color={TOTAL_COLOR}
                         {agencyName}
@@ -508,7 +521,7 @@
                   <div class="h-[280px]">
                     {#if isRateMetric}
                       <StatewideComparisonChart
-                        statewideSeries={panel.statewideSeries}
+                        statewideSeries={isStatewidePage ? EMPTY_RATE_SERIES : panel.statewideSeries}
                         selectedSeries={panel.selectedSeries}
                         {allYears}
                         yMax={panel.yMax}
@@ -522,7 +535,7 @@
                         selectedSeries={panel.selectedSeries}
                         {allYears}
                         yMax={panel.yMax}
-                        useSqrt={useSqrtScale && !isRateMetric}
+                        useSqrt={useSqrtScale && !isRateMetric && !isStatewidePage}
                         {isRateMetric}
                         color={panel.color}
                         {agencyName}
@@ -535,7 +548,7 @@
             {/each}
           </div>
 
-          {#if agencyName}
+          {#if agencyName && !isStatewidePage}
             {#if isRateMetric}
               <p class="mt-3 text-[10px] text-slate-400">
                 <span style="color:{TOTAL_COLOR}" class="font-semibold">{agencyName}</span>

--- a/packages/web/src/lib/components/SearchBox.svelte
+++ b/packages/web/src/lib/components/SearchBox.svelte
@@ -1,6 +1,7 @@
 <script>
   import { goto } from "$app/navigation";
   import { QuickScore } from "quick-score";
+  import { STATEWIDE_SLUG, STATEWIDE_AGG_NORMALIZED } from "$lib/statewide.js";
   import { searchState } from "$lib/stores/search";
   import { getLocale } from "$lib/paraglide/runtime";
   import {
@@ -137,7 +138,23 @@
       ...strongMatches.sort(compareStrong),
       ...fuzzyMatches.sort(compareFuzzy),
     ].slice(0, 10);
-    results = reranked;
+
+    // Pin the statewide overview ("Missouri (all agencies)") to the top while the
+    // query is still a prefix of its name ("m" → "missouri" → "missouri all…").
+    // It has no stop count, so it would otherwise sort last; and specific queries
+    // like "missouri state highway patrol" aren't a prefix, so they rank normally.
+    if (STATEWIDE_AGG_NORMALIZED.startsWith(queryNorm)) {
+      const statewide = enrichedAgencies.find((a) => toSlug(a) === STATEWIDE_SLUG);
+      if (statewide) {
+        const existing = reranked.find((e) => toSlug(e.item) === STATEWIDE_SLUG);
+        const rest = reranked.filter((e) => toSlug(e.item) !== STATEWIDE_SLUG);
+        results = [existing ?? { item: statewide, score: 1 }, ...rest].slice(0, 10);
+      } else {
+        results = reranked;
+      }
+    } else {
+      results = reranked;
+    }
   } else {
     results = [];
   }

--- a/packages/web/src/lib/statewide.js
+++ b/packages/web/src/lib/statewide.js
@@ -1,0 +1,18 @@
+/**
+ * The synthetic "agency" that represents the statewide aggregate — the sum of
+ * every reporting agency ("Missouri (all agencies)"). It lives in the agency
+ * index and the metric_year files like a normal agency, but it needs special
+ * handling: its count magnitudes dwarf every real agency (so it must never be
+ * drawn as a grey spaghetti line), and its own page is stripped down to census
+ * + statewide trends.
+ */
+
+/** agency_slug of the statewide aggregate row. */
+export const STATEWIDE_SLUG = "missouri-all-agencies";
+
+/**
+ * Canonical name normalized the same way the charts/search normalize agency
+ * names (lowercase, non-alphanumeric runs → single space, trimmed):
+ * "Missouri (all agencies)" → "missouri all agencies".
+ */
+export const STATEWIDE_AGG_NORMALIZED = "missouri all agencies";

--- a/packages/web/src/routes/agency/[slug]/+layout.svelte
+++ b/packages/web/src/routes/agency/[slug]/+layout.svelte
@@ -14,6 +14,7 @@
   import { onMount, tick } from "svelte";
   import * as m from "$lib/paraglide/messages";
   import { withDataBase } from "$lib/dataBase";
+  import { STATEWIDE_SLUG } from "$lib/statewide.js";
   import { getLocale } from "$lib/paraglide/runtime";
   import {
     agency_location_heading,
@@ -153,6 +154,11 @@
 
   // v2: latestYearData is SSR-loaded; other years are lazy-loaded client-side.
   $: agencyData = data.latestYearData;
+  // The synthetic statewide aggregate ("Missouri (all agencies)") gets a
+  // stripped-down page: no map, no agency metadata card, no neighbors, no
+  // peer scatter. Just identity → census (when the backend ships it) → the
+  // statewide metric table/charts (which suppress the grey spaghetti).
+  $: isStatewide = data.slug === STATEWIDE_SLUG;
   $: baselines = Array.isArray(data.baselines) ? data.baselines : [];
   $: agencyCount = Number(data?.agencyCount) || 0;
   $: metadata = agencyData?.agency_metadata;
@@ -1526,6 +1532,7 @@
     {/if}
   </header>
 
+  {#if !isStatewide}
   <section class="mb-1 grid gap-4 md:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)] md:items-start">
     <div class="rounded-2xl border border-slate-200 bg-white p-3">
       {#if stopVolumeLead}
@@ -1709,6 +1716,7 @@
     {localeBase}
     agencySlug={agencyData?.agency ?? data.slug}
   />
+  {/if}
 
   <CensusPanel
     {geocodioDemographics}
@@ -1830,14 +1838,16 @@
                 {" "}{agency_reporting_count({ count: stopCountFormatter.format(reportingAgencyCount), year: selectedYear })}
               {/if}
             </p>
-            <ScatterSection
-              {years}
-              {selectedYear}
-              agencyName={agencyData?.agency ?? data.slug}
-              excludeAgencies={scatterExcludedAgencies}
-              {formatPercentTick}
-              on:yearselect={(e) => selectYear(e.detail.year, e.detail.source)}
-            />
+            {#if !isStatewide}
+              <ScatterSection
+                {years}
+                {selectedYear}
+                agencyName={agencyData?.agency ?? data.slug}
+                excludeAgencies={scatterExcludedAgencies}
+                {formatPercentTick}
+                on:yearselect={(e) => selectYear(e.detail.year, e.detail.source)}
+              />
+            {/if}
           </div>
         {/if}
       </article>


### PR DESCRIPTION
Makes the synthetic **"Missouri (all agencies)"** aggregate (slug `missouri-all-agencies`) behave sensibly across charts, its own page, and search. New shared constants in `$lib/statewide.js`.

## What & why

- **Chart scaling (every agency page).** The aggregate is no longer drawn as a grey count spaghetti line. Its Σ-all-agencies magnitude (~1.7M — the single largest row in `metric_year/stops.json`) was pinning the top of every non-rate y-axis and squashing real agencies. Rate charts still use it as the legitimate stop-weighted "MO" reference.
- **Statewide page stripped.** No map, no agency info/metadata card, no neighbors, no peer scatter — none apply to the aggregate. Keeps identity, the census panel, and the metric table/charts.
- **Statewide charts draw a single line.** Count charts suppress the grey series and the now-meaningless filter/scale controls, and force a **linear** scale (sqrt would otherwise kick in on the ~1.7M total). Rate charts drop the redundant grey "MO" line (it would coincide with the selected line); the legend is hidden.
- **Search.** "Missouri (all agencies)" pins to the top while the query is a prefix of its name (`m` → `missouri` → `missouri all…`). It has `stops: null`, so it would otherwise sort last; specific queries like `missouri state highway patrol` aren't a prefix and rank normally.

## Note / follow-up

The statewide `agency_year` record currently has **no ACS/census data**, so `CensusPanel` renders nothing on the statewide page for now (it self-hides on null). Once the backend emits statewide ACS into that record's `geocode_jurisdiction_response`, the existing panel lights up with **no frontend change**.

## Testing

`svelte-check` clean (no new errors). Best verified on staging — load `/agency/missouri-all-agencies` (stripped page, single-line linear charts, no controls) and open a normal agency's count chart (real agencies no longer crushed by the aggregate line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)