### PR TITLE
Fix Spanish SSR: wire Paraglide locale into the server, localize canonicals

### DIFF
--- a/packages/web/src/hooks.server.ts
+++ b/packages/web/src/hooks.server.ts
@@ -1,6 +1,7 @@
 import { redirect } from "@sveltejs/kit";
 import { env } from "$env/dynamic/private";
 import { extractLocaleFromHeader } from "$lib/paraglide/runtime";
+import { paraglideMiddleware } from "$lib/paraglide/server";
 import { GATE_COOKIE, isGateOpen } from "$lib/server/gate";
 
 // Top-level paths that are NOT locale-prefixed pages — endpoints, static
@@ -64,8 +65,18 @@ export const handle = async ({ event, resolve }) => {
     throw redirect(307, `/${locale}${pathname}${search}`);
   }
 
-  const locale = firstSegment === "es" ? "es" : "en";
+  // Locale-prefixed pages must render through the Paraglide middleware —
+  // without it, server-side getLocale() is stuck on "en" and every /es page
+  // SSRs as an English duplicate whose canonical points at /en.
+  if (firstSegment === "en" || firstSegment === "es") {
+    return paraglideMiddleware(event.request, ({ request, locale }) => {
+      event.request = request;
+      return resolve(event, {
+        transformPageChunk: ({ html }) => html.replace("%lang%", locale),
+      });
+    });
+  }
   return resolve(event, {
-    transformPageChunk: ({ html }) => html.replace("%lang%", locale),
+    transformPageChunk: ({ html }) => html.replace("%lang%", "en"),
   });
 };

--- a/packages/web/src/routes/analysis/+page.svelte
+++ b/packages/web/src/routes/analysis/+page.svelte
@@ -12,6 +12,9 @@
   $: localeBase = locales.includes(currentLocale) ? `/${currentLocale}` : "/en";
   $: articles = publishedArticles();
 
+  const siteUrl = import.meta.env.PUBLIC_SITE_URL ?? "https://vsr.recoveredfactory.net";
+  $: canonicalUrl = `${siteUrl}${localeBase}/analysis`;
+
   const fmtDate = (iso, locale) =>
     new Date(iso + "T00:00:00").toLocaleDateString(locale === "es" ? "es" : "en-US", {
       year: "numeric",
@@ -23,6 +26,11 @@
 <svelte:head>
   <title>{analysis_index_title()}</title>
   <meta name="description" content={analysis_index_intro()} />
+  <link rel="canonical" href={canonicalUrl} />
+  <link rel="alternate" hreflang="en" href="{siteUrl}/en/analysis" />
+  <link rel="alternate" hreflang="es" href="{siteUrl}/es/analysis" />
+  <link rel="alternate" hreflang="x-default" href="{siteUrl}/en/analysis" />
+  <meta property="og:url" content={canonicalUrl} />
 </svelte:head>
 
 <StickyHeader />

--- a/packages/web/src/routes/analysis/first-impressions-2025/+page.md
+++ b/packages/web/src/routes/analysis/first-impressions-2025/+page.md
@@ -75,8 +75,9 @@ authors:
 <svelte:head>
   <title>First impressions of the 2025 Missouri Vehicle Stops Report</title>
   <meta name="description" content={metaDescription} />
+  <link rel="canonical" href="{siteUrl}/en/analysis/first-impressions-2025" />
   <meta property="og:type" content="article" />
-  <meta property="og:url" content="{siteUrl}/analysis/first-impressions-2025" />
+  <meta property="og:url" content="{siteUrl}/en/analysis/first-impressions-2025" />
   <meta property="og:title" content="First impressions of the 2025 Missouri Vehicle Stops Report" />
   <meta property="og:description" content={metaDescription} />
   <meta property="og:image" content={ogImage} />

--- a/packages/web/src/routes/sitemap.xml/+server.js
+++ b/packages/web/src/routes/sitemap.xml/+server.js
@@ -1,3 +1,5 @@
+import { publishedArticles } from "$lib/analysis/articles";
+
 const BASE_URL = import.meta.env.PUBLIC_SITE_URL || "https://vsr.recoveredfactory.net";
 const LOCALES = ["en", "es"];
 
@@ -34,6 +36,14 @@ ${xDefault}
   ).join("\n");
 }
 
+// English-only pages (untranslated articles) get a single /en <loc> with no
+// hreflang cluster — the /es URL canonicalizes to /en and isn't listed.
+function enOnlyEntry(path, lastmod) {
+  return `  <url>
+    <loc>${xmlEscape(locUrl("en", path))}</loc>
+${lastmod ? `    <lastmod>${lastmod}</lastmod>\n` : ""}  </url>`;
+}
+
 // Best-effort: pull a site-wide lastmod from the data manifest. Falls back
 // to nothing rather than a misleading current-day stamp.
 async function fetchLastmod(fetch) {
@@ -59,7 +69,11 @@ export async function GET({ fetch }) {
   ]);
   const agencies = agenciesRes.ok ? await agenciesRes.json() : [];
 
-  const entries = [urlEntry("/", lastmod), urlEntry("/287g", lastmod)];
+  const entries = [urlEntry("/", lastmod), urlEntry("/287g", lastmod), urlEntry("/analysis", lastmod)];
+  for (const article of publishedArticles()) {
+    const path = `/analysis/${article.slug}`;
+    entries.push(article.hasSpanish ? urlEntry(path, article.date) : enOnlyEntry(path, article.date));
+  }
   for (const agency of agencies) {
     if (agency.agency_slug) {
       entries.push(urlEntry(`/agency/${agency.agency_slug}`, lastmod));


### PR DESCRIPTION
Closes #217.

**The bug:** `hooks.server.ts` replaced `%lang%` from the URL but never wired the Paraglide runtime, so server-side `getLocale()` returned `en` on every request. Every `/es/...` URL was served to crawlers as English content whose canonical pointed at the `/en` twin — half the sitemap self-reporting as duplicates. Hydration re-resolved the locale client-side, so readers saw Spanish and the bug was invisible in a browser.

**The fix:** locale-prefixed pages now render through `paraglideMiddleware` (same pattern as 287g-explorer). Also:
- `/analysis` index: canonical + hreflang + `og:url` added (had none)
- article page: canonical added, `og:url` fixed (pointed at the unprefixed URL, a 307). English-only article, so both locales canonicalize to `/en`
- sitemap: `/analysis` + published articles added; untranslated articles listed as a single `/en` loc with no hreflang cluster

**Verified on dev**, both locales: `/es`, `/es/287g`, `/es/agency/*` now SSR in Spanish with self-referential `/es` canonicals; `/en` unchanged; bare-path 307s intact; sitemap output checked. svelte-check adds no new error classes (the repo baseline is ~884 pre-existing implicit-any errors; the touched JS file already had them on every function).

**Noticed, not touched:** `/about-data` 404s in production today (pre-existing, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)